### PR TITLE
Remove protobuf dependency from Fetch method

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -33,7 +33,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	pb "github.com/vimeo/galaxycache/galaxycachepb"
 	"github.com/vimeo/galaxycache/lru"
 	"github.com/vimeo/galaxycache/singleflight"
 
@@ -344,16 +343,11 @@ func (g *Galaxy) getLocally(ctx context.Context, key string, dest Sink) (ByteVie
 }
 
 func (g *Galaxy) getFromPeer(ctx context.Context, peer RemoteFetcher, key string) (ByteView, error) {
-	req := &pb.GetRequest{
-		Galaxy: g.name,
-		Key:    key,
-	}
-	res := &pb.GetResponse{}
-	err := peer.Fetch(ctx, req, res)
+	data, err := peer.Fetch(ctx, g.name, key)
 	if err != nil {
 		return ByteView{}, err
 	}
-	value := ByteView{b: res.Value}
+	value := ByteView{b: data}
 	// TODO(bradfitz): use res.MinuteQps or something smart to
 	// conditionally populate hotCache.  For now just do it some
 	// percentage of the time.

--- a/galaxycache_test.go
+++ b/galaxycache_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	pb "github.com/vimeo/galaxycache/galaxycachepb"
 	testpb "github.com/vimeo/galaxycache/testpb"
 )
 
@@ -240,13 +239,12 @@ func (fetcher *TestFetcher) Close() error {
 
 type testFetchers []RemoteFetcher
 
-func (fetcher *TestFetcher) Fetch(ctx context.Context, in *pb.GetRequest, out *pb.GetResponse) error {
+func (fetcher *TestFetcher) Fetch(ctx context.Context, galaxy string, key string) ([]byte, error) {
 	if fetcher.fail {
-		return errors.New("simulated error from peer")
+		return nil, errors.New("simulated error from peer")
 	}
 	fetcher.hits++
-	out.Value = []byte("got:" + in.GetKey())
-	return nil
+	return []byte("got:" + key), nil
 }
 
 func (proto *TestProtocol) NewFetcher(url string) (RemoteFetcher, error) {

--- a/http.go
+++ b/http.go
@@ -167,7 +167,7 @@ func (h *httpFetcher) Fetch(ctx context.Context, galaxy string, key string) ([]b
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned: %v", res.Status)
+		return nil, fmt.Errorf("server returned HTTP response status code: %v", res.Status)
 	}
 	data, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -130,13 +130,6 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
-	// Write the value to the response body as a proto message.
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/x-protobuf")
 	w.Write(value)
 }
 

--- a/http.go
+++ b/http.go
@@ -24,9 +24,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
-	pb "github.com/vimeo/galaxycache/galaxycachepb"
-
 	"go.opencensus.io/stats"
 )
 
@@ -135,13 +132,12 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Write the value to the response body as a proto message.
-	body, err := proto.Marshal(&pb.GetResponse{Value: value})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/x-protobuf")
-	w.Write(body)
+	w.Write(value)
 }
 
 type httpFetcher struct {

--- a/http.go
+++ b/http.go
@@ -17,14 +17,12 @@ limitations under the License.
 package galaxycache
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 
 	"github.com/golang/protobuf/proto"
 	pb "github.com/vimeo/galaxycache/galaxycachepb"
@@ -149,10 +147,6 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type httpFetcher struct {
 	transport func(context.Context) http.RoundTripper
 	baseURL   string
-}
-
-var bufferPool = sync.Pool{
-	New: func() interface{} { return new(bytes.Buffer) },
 }
 
 // Fetch here implements the RemoteFetcher interface for sending a GET request over HTTP to a peer

--- a/http.go
+++ b/http.go
@@ -130,6 +130,7 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Write(value)
 }
 

--- a/peers.go
+++ b/peers.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 
 	"github.com/vimeo/galaxycache/consistenthash"
-	pb "github.com/vimeo/galaxycache/galaxycachepb"
 )
 
 const defaultReplicas = 50
@@ -38,7 +37,7 @@ const defaultReplicas = 50
 // other peers; the PeerPicker contains a map of these fetchers corresponding
 // to each other peer address
 type RemoteFetcher interface {
-	Fetch(context context.Context, in *pb.GetRequest, out *pb.GetResponse) error
+	Fetch(context context.Context, galaxy string, key string) ([]byte, error)
 	// Close closes a client-side connection (may be a nop)
 	Close() error
 }


### PR DESCRIPTION
Change the Fetch method signature to take strings for galaxy and key instead of protobuf messages, and update the HTTP implementation accordingly.