### PR TITLE
Fix OpenCensus key tags and singleflighted metrics

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -301,7 +301,7 @@ func (g *Galaxy) Name() string {
 // canonical owner, call the BackendGetter to retrieve the value
 // (which will now be cached locally)
 func (g *Galaxy) Get(ctx context.Context, key string, dest Codec) error {
-	ctx, _ = tag.New(ctx, tag.Insert(galaxyKey, g.name))
+	ctx, _ = tag.New(ctx, tag.Insert(galaxyGetKey, g.name))
 
 	ctx, span := trace.StartSpan(ctx, "galaxycache.(*Galaxy).Get on "+g.name)
 	startTime := time.Now()

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -102,6 +102,10 @@ func (universe *Universe) NewGalaxy(name string, cacheBytes int64, getter Backen
 	if getter == nil {
 		panic("nil Getter")
 	}
+	if !isNameValid(name) {
+		panic("must use valid galaxy name")
+	}
+
 	universe.mu.Lock()
 	defer universe.mu.Unlock()
 
@@ -146,6 +150,12 @@ func (universe *Universe) NewGalaxy(name string, cacheBytes int64, getter Backen
 
 	universe.galaxies[name] = g
 	return g
+}
+
+func isNameValid(name string) bool {
+	// check galaxy name validity with tag.New() validity checks
+	_, err := tag.New(context.Background(), tag.Insert(galaxyGetKey, name))
+	return err == nil
 }
 
 // GetGalaxy returns the named galaxy previously created with NewGalaxy, or
@@ -305,7 +315,7 @@ func (g *Galaxy) Get(ctx context.Context, key string, dest Codec) error {
 	var tagErr error
 	ctx, tagErr = tag.New(ctx, tag.Insert(galaxyGetKey, g.name))
 	if tagErr != nil {
-		return fmt.Errorf("Error tagging context: %s", tagErr)
+		panic(fmt.Errorf("Error tagging context: %s", tagErr))
 	}
 
 	ctx, span := trace.StartSpan(ctx, "galaxycache.(*Galaxy).Get on "+g.name)

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -329,8 +329,9 @@ func (h hitLevel) String() string {
 		return "peer"
 	case hitBackend:
 		return "backend"
+	default:
+		return ""
 	}
-	return ""
 }
 
 func (h hitLevel) isHit() bool {

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -312,8 +312,7 @@ func (g *Galaxy) Name() string {
 // canonical owner, call the BackendGetter to retrieve the value
 // (which will now be cached locally)
 func (g *Galaxy) Get(ctx context.Context, key string, dest Codec) error {
-	var tagErr error
-	ctx, tagErr = tag.New(ctx, tag.Insert(galaxyGetKey, g.name))
+	ctx, tagErr := tag.New(ctx, tag.Insert(galaxyGetKey, g.name))
 	if tagErr != nil {
 		panic(fmt.Errorf("Error tagging context: %s", tagErr))
 	}

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -301,7 +301,7 @@ func (g *Galaxy) Name() string {
 // canonical owner, call the BackendGetter to retrieve the value
 // (which will now be cached locally)
 func (g *Galaxy) Get(ctx context.Context, key string, dest Codec) error {
-	ctx, _ = tag.New(ctx, tag.Insert(keyCommand, "get")) // TODO: replace with galaxy tag
+	ctx, _ = tag.New(ctx, tag.Insert(galaxyKey, g.name))
 
 	ctx, span := trace.StartSpan(ctx, "galaxycache.(*Galaxy).Get on "+g.name)
 	startTime := time.Now()

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -27,6 +27,7 @@ package galaxycache // import "github.com/vimeo/galaxycache"
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -301,7 +302,11 @@ func (g *Galaxy) Name() string {
 // canonical owner, call the BackendGetter to retrieve the value
 // (which will now be cached locally)
 func (g *Galaxy) Get(ctx context.Context, key string, dest Codec) error {
-	ctx, _ = tag.New(ctx, tag.Insert(galaxyGetKey, g.name))
+	var tagErr error
+	ctx, tagErr = tag.New(ctx, tag.Insert(galaxyGetKey, g.name))
+	if tagErr != nil {
+		return fmt.Errorf("Error tagging context: %s", tagErr)
+	}
 
 	ctx, span := trace.StartSpan(ctx, "galaxycache.(*Galaxy).Get on "+g.name)
 	startTime := time.Now()

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -339,10 +339,10 @@ func (g *Galaxy) RecordRequest(ctx context.Context, h hitLevel) {
 	switch h {
 	case hitMaincache:
 		g.Stats.MaincacheHits.Add(1)
-		stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(CacheLevelKey, h.string())}, MCacheHits.M(1))
+		stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(CacheLevelKey, h.string())}, MCacheHits.M(1))
 	case hitHotcache:
 		g.Stats.HotcacheHits.Add(1)
-		stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(CacheLevelKey, h.string())}, MCacheHits.M(1))
+		stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(CacheLevelKey, h.string())}, MCacheHits.M(1))
 	case hitPeer:
 		g.Stats.PeerLoads.Add(1)
 		stats.Record(ctx, MPeerLoads.M(1))
@@ -362,7 +362,7 @@ func (g *Galaxy) RecordRequest(ctx context.Context, h hitLevel) {
 // canonical owner, call the BackendGetter to retrieve the value
 // (which will now be cached locally)
 func (g *Galaxy) Get(ctx context.Context, key string, dest Codec) error {
-	ctx, tagErr := tag.New(ctx, tag.Insert(GalaxyKey, g.name))
+	ctx, tagErr := tag.New(ctx, tag.Upsert(GalaxyKey, g.name))
 	if tagErr != nil {
 		panic(fmt.Errorf("Error tagging context: %s", tagErr))
 	}

--- a/observability.go
+++ b/observability.go
@@ -24,12 +24,6 @@ import (
 	"go.opencensus.io/tag"
 )
 
-const (
-	unitDimensionless = "1"
-	unitBytes         = "By"
-	unitMillisecond   = "ms"
-)
-
 var (
 	// Copied from https://github.com/census-instrumentation/opencensus-go/blob/ff7de98412e5c010eb978f11056f90c00561637f/plugin/ocgrpc/stats_common.go#L54
 	defaultBytesDistribution = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
@@ -39,25 +33,25 @@ var (
 
 // Opencensus stats
 var (
-	MGets              = stats.Int64("gets", "The number of Get requests", unitDimensionless)
-	MCacheHits         = stats.Int64("cache_hits", "The number of times that the cache was hit", unitDimensionless)
-	MPeerLoads         = stats.Int64("peer_loads", "The number of remote loads or remote cache hits", unitDimensionless)
-	MPeerLoadErrors    = stats.Int64("peer_errors", "The number of remote errors", unitDimensionless)
-	MLoads             = stats.Int64("loads", "The number of gets/cacheHits", unitDimensionless)
-	MLoadErrors        = stats.Int64("loads_errors", "The number of errors encountered during Get", unitDimensionless)
-	MCoalescedLoads    = stats.Int64("loads_deduped", "The number of loads coalesced by singleflight", unitDimensionless)
-	MBackendLoads      = stats.Int64("backend_loads", "The number of successful loads from the backend getter", unitDimensionless)
-	MBackendLoadErrors = stats.Int64("local_load_errors", "The number of failed backend loads", unitDimensionless)
+	MGets              = stats.Int64("gets", "The number of Get requests", stats.UnitDimensionless)
+	MCacheHits         = stats.Int64("cache_hits", "The number of times that the cache was hit", stats.UnitDimensionless)
+	MPeerLoads         = stats.Int64("peer_loads", "The number of remote loads or remote cache hits", stats.UnitDimensionless)
+	MPeerLoadErrors    = stats.Int64("peer_errors", "The number of remote errors", stats.UnitDimensionless)
+	MLoads             = stats.Int64("loads", "The number of gets/cacheHits", stats.UnitDimensionless)
+	MLoadErrors        = stats.Int64("loads_errors", "The number of errors encountered during Get", stats.UnitDimensionless)
+	MCoalescedLoads    = stats.Int64("coalesced_loads", "The number of loads coalesced by singleflight", stats.UnitDimensionless)
+	MBackendLoads      = stats.Int64("backend_loads", "The number of successful loads from the backend getter", stats.UnitDimensionless)
+	MBackendLoadErrors = stats.Int64("local_load_errors", "The number of failed backend loads", stats.UnitDimensionless)
 
-	MCoalescedCacheHits    = stats.Int64("coalesced_cache_hits", "The number of coalesced times that the cache was hit", unitDimensionless)
-	MCoalescedPeerLoads    = stats.Int64("coalesced_peer_loads", "The number of coalesced remote loads or remote cache hits", unitDimensionless)
-	MCoalescedBackendLoads = stats.Int64("coalesced_backend_loads", "The number of coalesced successful loads from the backend getter", unitDimensionless)
+	MCoalescedCacheHits    = stats.Int64("coalesced_cache_hits", "The number of coalesced times that the cache was hit", stats.UnitDimensionless)
+	MCoalescedPeerLoads    = stats.Int64("coalesced_peer_loads", "The number of coalesced remote loads or remote cache hits", stats.UnitDimensionless)
+	MCoalescedBackendLoads = stats.Int64("coalesced_backend_loads", "The number of coalesced successful loads from the backend getter", stats.UnitDimensionless)
 
-	MServerRequests = stats.Int64("server_requests", "The number of Gets that came over the network from peers", unitDimensionless)
-	MKeyLength      = stats.Int64("key_length", "The length of keys", unitBytes)
-	MValueLength    = stats.Int64("value_length", "The length of values", unitBytes)
+	MServerRequests = stats.Int64("server_requests", "The number of Gets that came over the network from peers", stats.UnitDimensionless)
+	MKeyLength      = stats.Int64("key_length", "The length of keys", stats.UnitBytes)
+	MValueLength    = stats.Int64("value_length", "The length of values", stats.UnitBytes)
 
-	MRoundtripLatencyMilliseconds = stats.Float64("roundtrip_latency", "Roundtrip latency in milliseconds", unitMillisecond)
+	MRoundtripLatencyMilliseconds = stats.Float64("roundtrip_latency", "Roundtrip latency in milliseconds", stats.UnitMilliseconds)
 )
 
 // GalaxyKey tags the name of the galaxy

--- a/observability.go
+++ b/observability.go
@@ -33,25 +33,25 @@ var (
 
 // Opencensus stats
 var (
-	MGets              = stats.Int64("gets", "The number of Get requests", stats.UnitDimensionless)
-	MCacheHits         = stats.Int64("cache_hits", "The number of times that the cache was hit", stats.UnitDimensionless)
-	MPeerLoads         = stats.Int64("peer_loads", "The number of remote loads or remote cache hits", stats.UnitDimensionless)
-	MPeerLoadErrors    = stats.Int64("peer_errors", "The number of remote errors", stats.UnitDimensionless)
-	MLoads             = stats.Int64("loads", "The number of gets/cacheHits", stats.UnitDimensionless)
-	MLoadErrors        = stats.Int64("loads_errors", "The number of errors encountered during Get", stats.UnitDimensionless)
-	MCoalescedLoads    = stats.Int64("coalesced_loads", "The number of loads coalesced by singleflight", stats.UnitDimensionless)
-	MBackendLoads      = stats.Int64("backend_loads", "The number of successful loads from the backend getter", stats.UnitDimensionless)
-	MBackendLoadErrors = stats.Int64("local_load_errors", "The number of failed backend loads", stats.UnitDimensionless)
+	MGets              = stats.Int64("galaxycache/gets", "The number of Get requests", stats.UnitDimensionless)
+	MLoads             = stats.Int64("galaxycache/loads", "The number of gets/cacheHits", stats.UnitDimensionless)
+	MLoadErrors        = stats.Int64("galaxycache/loads_errors", "The number of errors encountered during Get", stats.UnitDimensionless)
+	MCacheHits         = stats.Int64("galaxycache/cache_hits", "The number of times that the cache was hit", stats.UnitDimensionless)
+	MPeerLoads         = stats.Int64("galaxycache/peer_loads", "The number of remote loads or remote cache hits", stats.UnitDimensionless)
+	MPeerLoadErrors    = stats.Int64("galaxycache/peer_errors", "The number of remote errors", stats.UnitDimensionless)
+	MBackendLoads      = stats.Int64("galaxycache/backend_loads", "The number of successful loads from the backend getter", stats.UnitDimensionless)
+	MBackendLoadErrors = stats.Int64("galaxycache/local_load_errors", "The number of failed backend loads", stats.UnitDimensionless)
 
-	MCoalescedCacheHits    = stats.Int64("coalesced_cache_hits", "The number of coalesced times that the cache was hit", stats.UnitDimensionless)
-	MCoalescedPeerLoads    = stats.Int64("coalesced_peer_loads", "The number of coalesced remote loads or remote cache hits", stats.UnitDimensionless)
-	MCoalescedBackendLoads = stats.Int64("coalesced_backend_loads", "The number of coalesced successful loads from the backend getter", stats.UnitDimensionless)
+	MCoalescedLoads        = stats.Int64("galaxycache/coalesced_loads", "The number of loads coalesced by singleflight", stats.UnitDimensionless)
+	MCoalescedCacheHits    = stats.Int64("galaxycache/coalesced_cache_hits", "The number of coalesced times that the cache was hit", stats.UnitDimensionless)
+	MCoalescedPeerLoads    = stats.Int64("galaxycache/coalesced_peer_loads", "The number of coalesced remote loads or remote cache hits", stats.UnitDimensionless)
+	MCoalescedBackendLoads = stats.Int64("galaxycache/coalesced_backend_loads", "The number of coalesced successful loads from the backend getter", stats.UnitDimensionless)
 
-	MServerRequests = stats.Int64("server_requests", "The number of Gets that came over the network from peers", stats.UnitDimensionless)
-	MKeyLength      = stats.Int64("key_length", "The length of keys", stats.UnitBytes)
-	MValueLength    = stats.Int64("value_length", "The length of values", stats.UnitBytes)
+	MServerRequests = stats.Int64("galaxycache/server_requests", "The number of Gets that came over the network from peers", stats.UnitDimensionless)
+	MKeyLength      = stats.Int64("galaxycache/key_length", "The length of keys", stats.UnitBytes)
+	MValueLength    = stats.Int64("galaxycache/value_length", "The length of values", stats.UnitBytes)
 
-	MRoundtripLatencyMilliseconds = stats.Float64("roundtrip_latency", "Roundtrip latency in milliseconds", stats.UnitMilliseconds)
+	MRoundtripLatencyMilliseconds = stats.Float64("galaxycache/roundtrip_latency", "Roundtrip latency in milliseconds", stats.UnitMilliseconds)
 )
 
 // GalaxyKey tags the name of the galaxy
@@ -64,13 +64,13 @@ var CacheLevelKey = tag.MustNewKey("cache-hit-level")
 var AllViews = []*view.View{
 	{Name: "galaxycache/gets", Description: "The number of Get requests", TagKeys: []tag.Key{GalaxyKey}, Measure: MGets, Aggregation: view.Count()},
 	{Name: "galaxycache/loads", Description: "The number of loads after singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/coalesced_loads", Description: "The number of loads after singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MCoalescedLoads, Aggregation: view.Count()},
 	{Name: "galaxycache/cache_hits", Description: "The number of times that the cache was good", TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Measure: MCacheHits, Aggregation: view.Count()},
 	{Name: "galaxycache/peer_loads", Description: "The number of remote loads or remote cache hits", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerLoads, Aggregation: view.Count()},
 	{Name: "galaxycache/peer_errors", Description: "The number of remote errors", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerLoadErrors, Aggregation: view.Count()},
 	{Name: "galaxycache/backend_loads", Description: "The number of successful loads from the backend", TagKeys: []tag.Key{GalaxyKey}, Measure: MBackendLoads, Aggregation: view.Count()},
 	{Name: "galaxycache/backend_load_errors", Description: "The number of failed local backend loads", TagKeys: []tag.Key{GalaxyKey}, Measure: MBackendLoadErrors, Aggregation: view.Count()},
 
+	{Name: "galaxycache/coalesced_loads", Description: "The number of loads after singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MCoalescedLoads, Aggregation: view.Count()},
 	{Name: "galaxycache/coalesced_cache_hits", Description: "The number of coalesced times that the cache was hit", TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Measure: MCoalescedCacheHits, Aggregation: view.Count()},
 	{Name: "galaxycache/coalesced_peer_loads", Description: "The number of coalesced remote loads or remote cache hits", TagKeys: []tag.Key{GalaxyKey}, Measure: MCoalescedPeerLoads, Aggregation: view.Count()},
 	{Name: "galaxycache/coalesced_backend_loads", Description: "The number of coalesced successful loads from the backend getter", TagKeys: []tag.Key{GalaxyKey}, Measure: MCoalescedBackendLoads, Aggregation: view.Count()},
@@ -78,6 +78,7 @@ var AllViews = []*view.View{
 	{Name: "galaxycache/server_requests", Description: "The number of Gets that came over the network from peers", TagKeys: []tag.Key{GalaxyKey}, Measure: MServerRequests, Aggregation: view.Count()},
 	{Name: "galaxycache/key_length", Description: "The distribution of the key lengths", TagKeys: []tag.Key{GalaxyKey}, Measure: MKeyLength, Aggregation: defaultBytesDistribution},
 	{Name: "galaxycache/value_length", Description: "The distribution of the value lengths", TagKeys: []tag.Key{GalaxyKey}, Measure: MValueLength, Aggregation: defaultBytesDistribution},
+
 	{Name: "galaxycache/roundtrip_latency", Description: "The roundtrip latency", TagKeys: []tag.Key{GalaxyKey}, Measure: MRoundtripLatencyMilliseconds, Aggregation: defaultMillisecondsDistribution},
 }
 

--- a/observability.go
+++ b/observability.go
@@ -57,25 +57,24 @@ var (
 	MRoundtripLatencyMilliseconds = stats.Float64("roundtrip_latency", "Roundtrip latency in milliseconds", unitMillisecond)
 )
 
-var keyCommand, _ = tag.NewKey("command")
-var galaxyKey, err = tag.NewKey("galaxy-get") // TODO(willg): where to handle this err?
+var galaxyGetKey = tag.MustNewKey("galaxy-get")
 
 // AllViews is a slice of default views for people to use
 var AllViews = []*view.View{
-	{Name: "galaxycache/gets", Description: "The number of Get requests", Measure: MGets, Aggregation: view.Count()},
-	{Name: "galaxycache/cache_hits", Description: "The number of times that either cache was good", Measure: MCacheHits, Aggregation: view.Count()},
-	{Name: "galaxycache/hotcache_hits", Description: "The number of times that the hotcache was good", Measure: MHotcacheHits, Aggregation: view.Count()},
-	{Name: "galaxycache/cache_misses", Description: "The number of times that either cache was not good", Measure: MCacheMisses, Aggregation: view.Count()},
-	{Name: "galaxycache/peer_loads", Description: "The number of remote loads or remote cache hits", Measure: MPeerLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/peer_errors", Description: "The number of remote errors", Measure: MPeerErrors, Aggregation: view.Count()},
-	{Name: "galaxycache/loads", Description: "The number of loads after singleflight", Measure: MLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/loads_deduped", Description: "The number of loads after singleflight", Measure: MLoadsDeduped, Aggregation: view.Count()},
-	{Name: "galaxycache/local_loads", Description: "The number of good local loads", Measure: MLocalLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/local_load_errors", Description: "The number of bad local loads", Measure: MLocalLoadErrors, Aggregation: view.Count()},
-	{Name: "galaxycache/server_requests", Description: "The number of Gets that came over the network from peers", Measure: MServerRequests, Aggregation: view.Count()},
-	{Name: "galaxycache/key_length", Description: "The distribution of the key lengths", Measure: MKeyLength, Aggregation: defaultBytesDistribution},
-	{Name: "galaxycache/value_length", Description: "The distribution of the value lengths", Measure: MValueLength, Aggregation: defaultBytesDistribution},
-	{Name: "galaxycache/roundtrip_latency", Description: "The roundtrip latency", Measure: MRoundtripLatencyMilliseconds, Aggregation: defaultMillisecondsDistribution},
+	{Name: "galaxycache/gets", Description: "The number of Get requests", TagKeys: []tag.Key{galaxyGetKey}, Measure: MGets, Aggregation: view.Count()},
+	{Name: "galaxycache/cache_hits", Description: "The number of times that either cache was good", TagKeys: []tag.Key{galaxyGetKey}, Measure: MCacheHits, Aggregation: view.Count()},
+	{Name: "galaxycache/hotcache_hits", Description: "The number of times that the hotcache was good", TagKeys: []tag.Key{galaxyGetKey}, Measure: MHotcacheHits, Aggregation: view.Count()},
+	{Name: "galaxycache/cache_misses", Description: "The number of times that either cache was not good", TagKeys: []tag.Key{galaxyGetKey}, Measure: MCacheMisses, Aggregation: view.Count()},
+	{Name: "galaxycache/peer_loads", Description: "The number of remote loads or remote cache hits", TagKeys: []tag.Key{galaxyGetKey}, Measure: MPeerLoads, Aggregation: view.Count()},
+	{Name: "galaxycache/peer_errors", Description: "The number of remote errors", TagKeys: []tag.Key{galaxyGetKey}, Measure: MPeerErrors, Aggregation: view.Count()},
+	{Name: "galaxycache/loads", Description: "The number of loads after singleflight", TagKeys: []tag.Key{galaxyGetKey}, Measure: MLoads, Aggregation: view.Count()},
+	{Name: "galaxycache/loads_deduped", Description: "The number of loads after singleflight", TagKeys: []tag.Key{galaxyGetKey}, Measure: MLoadsDeduped, Aggregation: view.Count()},
+	{Name: "galaxycache/local_loads", Description: "The number of good local loads", TagKeys: []tag.Key{galaxyGetKey}, Measure: MLocalLoads, Aggregation: view.Count()},
+	{Name: "galaxycache/local_load_errors", Description: "The number of bad local loads", TagKeys: []tag.Key{galaxyGetKey}, Measure: MLocalLoadErrors, Aggregation: view.Count()},
+	{Name: "galaxycache/server_requests", Description: "The number of Gets that came over the network from peers", TagKeys: []tag.Key{galaxyGetKey}, Measure: MServerRequests, Aggregation: view.Count()},
+	{Name: "galaxycache/key_length", Description: "The distribution of the key lengths", TagKeys: []tag.Key{galaxyGetKey}, Measure: MKeyLength, Aggregation: defaultBytesDistribution},
+	{Name: "galaxycache/value_length", Description: "The distribution of the value lengths", TagKeys: []tag.Key{galaxyGetKey}, Measure: MValueLength, Aggregation: defaultBytesDistribution},
+	{Name: "galaxycache/roundtrip_latency", Description: "The roundtrip latency", TagKeys: []tag.Key{galaxyGetKey}, Measure: MRoundtripLatencyMilliseconds, Aggregation: defaultMillisecondsDistribution},
 }
 
 func sinceInMilliseconds(start time.Time) float64 {

--- a/observability.go
+++ b/observability.go
@@ -58,6 +58,7 @@ var (
 )
 
 var keyCommand, _ = tag.NewKey("command")
+var galaxyKey, err = tag.NewKey("galaxy-get") // TODO(willg): where to handle this err?
 
 // AllViews is a slice of default views for people to use
 var AllViews = []*view.View{

--- a/observability.go
+++ b/observability.go
@@ -62,24 +62,24 @@ var CacheLevelKey = tag.MustNewKey("cache-hit-level")
 
 // AllViews is a slice of default views for people to use
 var AllViews = []*view.View{
-	{Name: "galaxycache/gets", Description: "The number of Get requests", TagKeys: []tag.Key{GalaxyKey}, Measure: MGets, Aggregation: view.Count()},
-	{Name: "galaxycache/loads", Description: "The number of loads after singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/cache_hits", Description: "The number of times that the cache was good", TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Measure: MCacheHits, Aggregation: view.Count()},
-	{Name: "galaxycache/peer_loads", Description: "The number of remote loads or remote cache hits", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/peer_errors", Description: "The number of remote errors", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerLoadErrors, Aggregation: view.Count()},
-	{Name: "galaxycache/backend_loads", Description: "The number of successful loads from the backend", TagKeys: []tag.Key{GalaxyKey}, Measure: MBackendLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/backend_load_errors", Description: "The number of failed local backend loads", TagKeys: []tag.Key{GalaxyKey}, Measure: MBackendLoadErrors, Aggregation: view.Count()},
+	{Measure: MGets, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MCacheHits, TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Aggregation: view.Count()},
+	{Measure: MPeerLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MPeerLoadErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MBackendLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MBackendLoadErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 
-	{Name: "galaxycache/coalesced_loads", Description: "The number of loads after singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MCoalescedLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/coalesced_cache_hits", Description: "The number of coalesced times that the cache was hit", TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Measure: MCoalescedCacheHits, Aggregation: view.Count()},
-	{Name: "galaxycache/coalesced_peer_loads", Description: "The number of coalesced remote loads or remote cache hits", TagKeys: []tag.Key{GalaxyKey}, Measure: MCoalescedPeerLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/coalesced_backend_loads", Description: "The number of coalesced successful loads from the backend getter", TagKeys: []tag.Key{GalaxyKey}, Measure: MCoalescedBackendLoads, Aggregation: view.Count()},
+	{Measure: MCoalescedLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MCoalescedCacheHits, TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Aggregation: view.Count()},
+	{Measure: MCoalescedPeerLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MCoalescedBackendLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 
-	{Name: "galaxycache/server_requests", Description: "The number of Gets that came over the network from peers", TagKeys: []tag.Key{GalaxyKey}, Measure: MServerRequests, Aggregation: view.Count()},
-	{Name: "galaxycache/key_length", Description: "The distribution of the key lengths", TagKeys: []tag.Key{GalaxyKey}, Measure: MKeyLength, Aggregation: defaultBytesDistribution},
-	{Name: "galaxycache/value_length", Description: "The distribution of the value lengths", TagKeys: []tag.Key{GalaxyKey}, Measure: MValueLength, Aggregation: defaultBytesDistribution},
+	{Measure: MServerRequests, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MKeyLength, TagKeys: []tag.Key{GalaxyKey}, Aggregation: defaultBytesDistribution},
+	{Measure: MValueLength, TagKeys: []tag.Key{GalaxyKey}, Aggregation: defaultBytesDistribution},
 
-	{Name: "galaxycache/roundtrip_latency", Description: "The roundtrip latency", TagKeys: []tag.Key{GalaxyKey}, Measure: MRoundtripLatencyMilliseconds, Aggregation: defaultMillisecondsDistribution},
+	{Measure: MRoundtripLatencyMilliseconds, TagKeys: []tag.Key{GalaxyKey}, Aggregation: defaultMillisecondsDistribution},
 }
 
 func sinceInMilliseconds(start time.Time) float64 {

--- a/observability.go
+++ b/observability.go
@@ -39,17 +39,15 @@ var (
 
 // Opencensus stats
 var (
-	MGets            = stats.Int64("gets", "The number of Get requests", unitDimensionless)
-	MCacheHits       = stats.Int64("cache_hits", "The number of times that the cache was good", unitDimensionless)
-	MCacheMisses     = stats.Int64("cache_misses", "The number of times that either cache was not good", unitDimensionless)
-	MPeerLoads       = stats.Int64("peer_loads", "The number of remote loads or remote cache hits", unitDimensionless)
-	MPeerErrors      = stats.Int64("peer_errors", "The number of remote errors", unitDimensionless)
-	MLoads           = stats.Int64("loads", "The number of gets/cacheHits", unitDimensionless)
-	MLoadErrors      = stats.Int64("loads_errors", "The number of errors encountered during Get", unitDimensionless)
-	MLoadsDeduped    = stats.Int64("loads_deduped", "The number of loads after singleflight", unitDimensionless)
-	MLocalLoads      = stats.Int64("local_loads", "The number of good local loads", unitDimensionless)
-	MLocalLoadErrors = stats.Int64("local_load_errors", "The number of bad local loads", unitDimensionless)
-	MBackendLoads    = stats.Int64("backend_loads", "The number of good loads from the backend getter", unitDimensionless)
+	MGets              = stats.Int64("gets", "The number of Get requests", unitDimensionless)
+	MCacheHits         = stats.Int64("cache_hits", "The number of times that the cache was good", unitDimensionless)
+	MPeerLoads         = stats.Int64("peer_loads", "The number of remote loads or remote cache hits", unitDimensionless)
+	MPeerLoadErrors    = stats.Int64("peer_errors", "The number of remote errors", unitDimensionless)
+	MLoads             = stats.Int64("loads", "The number of gets/cacheHits", unitDimensionless)
+	MLoadErrors        = stats.Int64("loads_errors", "The number of errors encountered during Get", unitDimensionless)
+	MLoadsDeduped      = stats.Int64("loads_deduped", "The number of loads after singleflight", unitDimensionless)
+	MBackendLoads      = stats.Int64("backend_loads", "The number of good loads from the backend getter", unitDimensionless)
+	MBackendLoadErrors = stats.Int64("local_load_errors", "The number of bad local loads", unitDimensionless)
 
 	MSFCacheHits    = stats.Int64("sf_cache_hits", "The number of times that the cache was good while in singleflight", unitDimensionless)
 	MSFPeerLoads    = stats.Int64("sf_peer_loads", "The number of remote loads or remote cache hits in singleflight", unitDimensionless)
@@ -72,15 +70,13 @@ var CacheLevelKey = tag.MustNewKey("cache-hit-level")
 // AllViews is a slice of default views for people to use
 var AllViews = []*view.View{
 	{Name: "galaxycache/gets", Description: "The number of Get requests", TagKeys: []tag.Key{GalaxyKey}, Measure: MGets, Aggregation: view.Count()},
-	{Name: "galaxycache/cache_hits", Description: "The number of times that the cache was good", TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Measure: MCacheHits, Aggregation: view.Count()},
-	{Name: "galaxycache/cache_misses", Description: "The number of times that either cache was not good", TagKeys: []tag.Key{GalaxyKey}, Measure: MCacheMisses, Aggregation: view.Count()},
-	{Name: "galaxycache/peer_loads", Description: "The number of remote loads or remote cache hits", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/peer_errors", Description: "The number of remote errors", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerErrors, Aggregation: view.Count()},
 	{Name: "galaxycache/loads", Description: "The number of loads after singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MLoads, Aggregation: view.Count()},
 	{Name: "galaxycache/loads_deduped", Description: "The number of loads after singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MLoadsDeduped, Aggregation: view.Count()},
-	{Name: "galaxycache/local_loads", Description: "The number of good local loads", TagKeys: []tag.Key{GalaxyKey}, Measure: MLocalLoads, Aggregation: view.Count()},
-	{Name: "galaxycache/local_load_errors", Description: "The number of bad local loads", TagKeys: []tag.Key{GalaxyKey}, Measure: MLocalLoadErrors, Aggregation: view.Count()},
-	{Name: "galaxycache/backend_loads", Description: "The number of good backend loads", TagKeys: []tag.Key{GalaxyKey}, Measure: MBackendLoads, Aggregation: view.Count()},
+	{Name: "galaxycache/cache_hits", Description: "The number of times that the cache was good", TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Measure: MCacheHits, Aggregation: view.Count()},
+	{Name: "galaxycache/peer_loads", Description: "The number of remote loads or remote cache hits", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerLoads, Aggregation: view.Count()},
+	{Name: "galaxycache/peer_errors", Description: "The number of remote errors", TagKeys: []tag.Key{GalaxyKey}, Measure: MPeerLoadErrors, Aggregation: view.Count()},
+	{Name: "galaxycache/backend_loads", Description: "The number of good local backend loads", TagKeys: []tag.Key{GalaxyKey}, Measure: MBackendLoads, Aggregation: view.Count()},
+	{Name: "galaxycache/backend_load_errors", Description: "The number of bad local loads", TagKeys: []tag.Key{GalaxyKey}, Measure: MBackendLoadErrors, Aggregation: view.Count()},
 
 	{Name: "galaxycache/sf_cache_hits", Description: "The number of times that the cache was good while in singleflight", TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Measure: MSFCacheHits, Aggregation: view.Count()},
 	{Name: "galaxycache/sf_peer_loads", Description: "The number of remote loads or remote cache hits in singleflight", TagKeys: []tag.Key{GalaxyKey}, Measure: MSFPeerLoads, Aggregation: view.Count()},


### PR DESCRIPTION
- Change the tag to specify the Get() call on a galaxy with the galaxy name
- Add the key to all views