### PR TITLE
gRPC: don't copy bytes before sending on the wire.

### DIFF
--- a/grpc/grpcserver.go
+++ b/grpc/grpcserver.go
@@ -52,7 +52,7 @@ func (gp *serviceImpl) GetFromPeer(ctx context.Context, req *pb.GetRequest) (*pb
 
 	galaxy.Stats.ServerRequests.Add(1) // keep track of the num of req
 
-	var value gc.ByteCodec
+	var value unsafeByteCodec
 	err := galaxy.Get(ctx, req.Key, &value)
 	if err != nil {
 		return nil, status.Errorf(status.Code(err), "Failed to retrieve [%s]: %v", req, err)

--- a/grpc/unsafe_byte_codec.go
+++ b/grpc/unsafe_byte_codec.go
@@ -1,0 +1,17 @@
+package grpc
+
+// unsafeByteCodec is a byte slice type that implements Codec
+type unsafeByteCodec []byte
+
+// MarshalBinary returns the contained byte-slice
+func (c *unsafeByteCodec) MarshalBinary() ([]byte, error) {
+	return *c, nil
+}
+
+// UnmarshalBinary to provided data so they share the same backing array
+// this is a generally unsafe performance optimization, but safe in the context
+// of the gRPC server.
+func (c *unsafeByteCodec) UnmarshalBinary(data []byte) error {
+	*c = data
+	return nil
+}


### PR DESCRIPTION
Create an `unsafeByteCodec` local to the grpc package that does not copy
the byte-slice in `UnmarshalBinary()`. This should reduce heap
allocations, and may help high-throughput galaxycache gRPC servers with
GC-time.