### PR TITLE
hot/candidate cache: remove damping on key qps 

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -146,7 +146,7 @@ func (universe *Universe) NewGalaxy(name string, cacheBytes int64, getter Backen
 	gOpts := galaxyOpts{
 		promoter:          &promoter.DefaultPromoter{},
 		hcRatio:           8, // default hotcache size is 1/8th of cacheBytes
-		maxCandidates:     100,
+		maxCandidates:     1024,
 		clock:             clocks.DefaultClock(),
 		resetIdleStatsAge: time.Minute,
 	}

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -133,7 +133,7 @@ func (universe *Universe) NewGalaxy(name string, cacheBytes int64, getter Backen
 		panic("nil Getter")
 	}
 	if nameErr := isNameValid(name); nameErr != nil {
-		panic(fmt.Errorf("Invalid galaxy name: %s", nameErr))
+		panic(fmt.Errorf("invalid galaxy name: %s", nameErr))
 	}
 
 	universe.mu.Lock()
@@ -438,7 +438,7 @@ func (g *Galaxy) recordRequest(ctx context.Context, h hitLevel, localAuthoritati
 func (g *Galaxy) Get(ctx context.Context, key string, dest Codec) error {
 	ctx, tagErr := tag.New(ctx, tag.Upsert(GalaxyKey, g.name))
 	if tagErr != nil {
-		panic(fmt.Errorf("Error tagging context: %s", tagErr))
+		panic(fmt.Errorf("error tagging context: %s", tagErr))
 	}
 
 	ctx, span := trace.StartSpan(ctx, "galaxycache.(*Galaxy).Get on "+g.name)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/golang/protobuf v1.4.3
+	github.com/vimeo/go-clocks v1.1.2
 	go.opencensus.io v0.22.5
 	google.golang.org/grpc v1.35.0
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/vimeo/go-clocks v1.1.2 h1:HAh+gZT4PIIWJEIc/cXi1EPExZWMUgL/9lO0SA+EPrw=
+github.com/vimeo/go-clocks v1.1.2/go.mod h1:coJz9AfolJ/xWbjgudyoJew7Kw/kV17P3fLIumNLjEg=
 go.opencensus.io v0.22.5 h1:dntmOdLpSpHlVqbW5Eay97DelsZHe+55D+xC6i0dDS0=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/peers.go
+++ b/peers.go
@@ -138,7 +138,7 @@ func (pp *PeerPicker) shutdown() error {
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("Failed to close: %v", errs)
+		return fmt.Errorf("failed to close: %v", errs)
 	}
 	return nil
 }

--- a/promoter/promoter.go
+++ b/promoter/promoter.go
@@ -75,3 +75,15 @@ type DefaultPromoter struct{}
 func (p *DefaultPromoter) ShouldPromote(key string, data []byte, stats Stats) bool {
 	return stats.KeyQPS >= stats.HCStats.LeastRecentQPS
 }
+
+// PreviouslyKnownPromoter implements Promoter and promotes the given key if
+// the key has been seen before (was previously present in the candidate cache).
+type PreviouslyKnownPromoter struct{}
+
+// ShouldPromote for the PreviouslyKnownPromoter promotes if the Hits value is
+// non-zero, indicating that the key has been seen before.
+func (p *PreviouslyKnownPromoter) ShouldPromote(key string, data []byte, stats Stats) bool {
+	// stats.Hits is explicitly documented to be zero if this is the first
+	// hit for the key (that this Galaxy knows of)
+	return stats.Hits > 0
+}

--- a/promoter/promoter.go
+++ b/promoter/promoter.go
@@ -30,7 +30,12 @@ type HCStats struct {
 // Stats contains both the KeyQPS and a pointer to the galaxy-wide
 // HCStats
 type Stats struct {
-	KeyQPS  float64
+	// Request-rate for this key (possibly with some windowing applied)
+	KeyQPS float64
+	// Number of hits for this key (also possibly with some windowing applied)
+	// This will be zero if there is no record of this key (not seen before
+	// or tracking expired)
+	Hits    int64
 	HCStats *HCStats
 }
 


### PR DESCRIPTION
The damping was a bit problematic in that it prevented any hits less
than a second after the initial candidate-cache insertion from having a
non-zero qps calculated.

In this new windowed-QPS type, we specifically avoid including a
time.Time so there are no pointers for the Garbage Collector to scan. As
such, we now measure time relative to a new `baseTime` in the Galaxy. To
facilitate testing, time is now managed by an implementation of the
go-clocks package's Clock interface.

Additionally, this has a few other properties:
 - After some time a value is considered "stale" and reset. (so as not
   to penalize a key that's hung in the candidate cache for hours
   relative to one that's been evicted and brought back)
 - QPS is calculated relative to the current "epoch" for that key (which
   is either the creation time or the last time it was reset due to
   staleness.

To facilitate a simpler Promoter implementation, we add a Hits field
that's guaranteed to be 0 on the first fetch.

Additionally:
 - fix a few lints for capitalized error-messages
 - bump the default candidate cache size from 100 to 1024 so there's a better chance of a hit in higher-throughput cases
 - implement a new promoter that always promotes a key that's was in the candidate cache.