### PR TITLE
Fix an invariant violation in the typed Linked List implementation and add testing/benchmarking infrastructure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.17, 1.18, '1.19.0-rc.2']
+        goversion: [1.17, 1.18, '1.19']
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
         uses: actions/setup-go@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,3 +41,12 @@ jobs:
         env:
           GO111MODULE: on
         run: go test -race -mod=readonly -count 2 ./...
+
+        # Run all the tests with the paranoid linked-list checks enabled
+      - name: Race Test Paranoid LinkedList
+        env:
+          GO111MODULE: on
+        run: |
+          sed -e 's/const paranoidLL = false/const paranoidLL = true/' < lru/typed_ll.go > lru/typed_ll.go.new
+          mv lru/typed_ll.go.new lru/typed_ll.go
+          go test -race -mod=readonly -count 2 ./...

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -95,3 +95,22 @@ func TestEvict(t *testing.T) {
 		t.Fatalf("got %v in second evicted key; want %s", evictedKeys[1], "myKey1")
 	}
 }
+
+func BenchmarkGetAllHits(b *testing.B) {
+	b.ReportAllocs()
+	type complexStruct struct {
+		a, b, c, d, e, f int64
+		k, l, m, n, o, p float64
+	}
+	// Populate the cache
+	l := New(32)
+	for z := 0; z < 32; z++ {
+		l.Add(z, &complexStruct{a: int64(z)})
+	}
+
+	b.ResetTimer()
+	for z := 0; z < b.N; z++ {
+		// take the lower 5 bits as mod 32 so we always hit
+		l.Get(z & 31)
+	}
+}

--- a/lru/typed_ll.go
+++ b/lru/typed_ll.go
@@ -77,6 +77,9 @@ func (l *linkedList[T]) MoveToFront(e *llElem[T]) {
 	if l.tail == e {
 		l.tail = e.prev
 	}
+	e.next = l.head
+	l.head = e
+	e.prev = nil
 }
 
 func (l *linkedList[T]) Remove(e *llElem[T]) {

--- a/lru/typed_ll.go
+++ b/lru/typed_ll.go
@@ -18,6 +18,13 @@ limitations under the License.
 
 package lru
 
+import "fmt"
+
+// Default-disable paranoid checks so they get compiled out.
+// If this const is renamed/moved/updated make sure to update the sed
+// expression in the github action. (.github/workflows/go.yml)
+const paranoidLL = false
+
 // LinkedList using generics to reduce the number of heap objects
 // Used for the LRU stack in TypedCache
 type linkedList[T any] struct {
@@ -40,6 +47,10 @@ func (l *llElem[T]) Prev() *llElem[T] {
 }
 
 func (l *linkedList[T]) PushFront(val T) *llElem[T] {
+	if paranoidLL {
+		l.checkHeadTail()
+		defer l.checkHeadTail()
+	}
 	elem := llElem[T]{
 		next:  l.head,
 		prev:  nil, // first element
@@ -58,6 +69,14 @@ func (l *linkedList[T]) PushFront(val T) *llElem[T] {
 }
 
 func (l *linkedList[T]) MoveToFront(e *llElem[T]) {
+	if paranoidLL {
+		if e == nil {
+			panic("nil element")
+		}
+		l.checkHeadTail()
+		defer l.checkHeadTail()
+	}
+
 	if l.head == e {
 		// nothing to do
 		return
@@ -82,7 +101,38 @@ func (l *linkedList[T]) MoveToFront(e *llElem[T]) {
 	e.prev = nil
 }
 
+func (l *linkedList[T]) checkHeadTail() {
+	if !paranoidLL {
+		return
+	}
+	if (l.head != nil) != (l.tail != nil) {
+		panic(fmt.Sprintf("invariant failure; nilness mismatch: head: %+v; tail: %+v (size %d)",
+			l.head, l.tail, l.size))
+	}
+
+	if l.size > 0 && (l.head == nil || l.tail == nil) {
+		panic(fmt.Sprintf("invariant failure; head and/or tail nil with %d size: head: %+v; tail: %+v",
+			l.size, l.head, l.tail))
+	}
+
+	if l.head != nil && (l.head.prev != nil || (l.head.next == nil && l.size != 1)) {
+		panic(fmt.Sprintf("invariant failure; head next/prev invalid with %d size: head: %+v; tail: %+v",
+			l.size, l.head, l.tail))
+	}
+	if l.tail != nil && ((l.tail.prev == nil && l.size != 1) || l.tail.next != nil) {
+		panic(fmt.Sprintf("invariant failure; tail next/prev invalid with %d size: head: %+v; tail: %+v",
+			l.size, l.head, l.tail))
+	}
+}
+
 func (l *linkedList[T]) Remove(e *llElem[T]) {
+	if paranoidLL {
+		if e == nil {
+			panic("nil element")
+		}
+		l.checkHeadTail()
+		defer l.checkHeadTail()
+	}
 	if l.tail == e {
 		l.tail = e.prev
 	}

--- a/lru/typed_lru_test.go
+++ b/lru/typed_lru_test.go
@@ -82,6 +82,14 @@ func TestTypedEvict(t *testing.T) {
 	if evictedKeys[1] != Key("myKey1") {
 		t.Fatalf("got %v in second evicted key; want %s", evictedKeys[1], "myKey1")
 	}
+	// move 9 and 10 to the head
+	lru.Get("myKey10")
+	lru.Get("myKey9")
+	// add another few keys to evict the the others
+	for i := 22; i < 32; i++ {
+		lru.Add(fmt.Sprintf("myKey%d", i), 1234)
+	}
+
 }
 
 func BenchmarkTypedGetAllHits(b *testing.B) {

--- a/lru/typed_lru_test.go
+++ b/lru/typed_lru_test.go
@@ -83,3 +83,41 @@ func TestTypedEvict(t *testing.T) {
 		t.Fatalf("got %v in second evicted key; want %s", evictedKeys[1], "myKey1")
 	}
 }
+
+func BenchmarkTypedGetAllHits(b *testing.B) {
+	b.ReportAllocs()
+	type complexStruct struct {
+		a, b, c, d, e, f int64
+		k, l, m, n, o, p float64
+	}
+	// Populate the cache
+	l := TypedNew[int, complexStruct](32)
+	for z := 0; z < 32; z++ {
+		l.Add(z, complexStruct{a: int64(z)})
+	}
+
+	b.ResetTimer()
+	for z := 0; z < b.N; z++ {
+		// take the lower 5 bits as mod 32 so we always hit
+		l.Get(z & 31)
+	}
+}
+
+func BenchmarkTypedGetHalfHits(b *testing.B) {
+	b.ReportAllocs()
+	type complexStruct struct {
+		a, b, c, d, e, f int64
+		k, l, m, n, o, p float64
+	}
+	// Populate the cache
+	l := TypedNew[int, complexStruct](32)
+	for z := 0; z < 32; z++ {
+		l.Add(z, complexStruct{a: int64(z)})
+	}
+
+	b.ResetTimer()
+	for z := 0; z < b.N; z++ {
+		// take the lower 4 bits as mod 16 shifted left by 1 to
+		l.Get((z&15)<<1 | z&16>>4 | z&1<<4)
+	}
+}


### PR DESCRIPTION
A small fix to typed_ll.go fixing invariant adherence in `MoveToFront()`. (three pointer assignments were missed)
This invariant violation would lead the LRU-stack (the linked-list) to get into an invalid state, where the tail pointer is `nil` (and the head pointer is pointing to the incorrect element).

This lead the `Remove()` method to exit early (without doing anything) when the it was evicting the tail element. As a result, `(*cache).removeOldest` in the top-level package would loop indefinitely, as nothing was removed, `bytes()` would return the exact same value every time.

Add some benchmarks because I originally thought this was a performance regression, rather than an infinite loop.
Add some new tests to cover the bug and exercise a number of possible concurrency issues.

It was useful to add some paranoid checks for invariants in the linked-list implementation, and rather than removing them (since they're a bit expensive), they are gated with a `paranoidLL` constant. Github actions is updated to re-run all the tests with that flipped to true with the race-detector enabled after running vanilla.

I uncovered a few performance optimizations while digging into this. Those will be in a follow-up PR.