### PR TITLE
Don't Run Format Under Go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: gofmt
+        if: ${{matrix.goversion == '1.19'}}
         run: |
           [[ -z  $(gofmt -l $(find . -name '*.go') ) ]]
 


### PR DESCRIPTION
gofmt is not aware of build tags and will choke on 1.18+ syntax.  Instead, just focus the format checks on the latest go (1.19).