### PR TITLE
Incremental peer add & remove

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -96,7 +96,7 @@ type Universe struct {
 // NewUniverse is the main constructor for the Universe object. It is passed a
 // FetchProtocol (to specify fetching via GRPC or HTTP) and its own URL along
 // with options.
-func NewUniverse(protocol FetchProtocol, selfURL string, opts ...UniverseOpt) *Universe {
+func NewUniverse(protocol FetchProtocol, selfID string, opts ...UniverseOpt) *Universe {
 	options := &universeOpts{}
 	for _, opt := range opts {
 		opt(options)
@@ -104,7 +104,7 @@ func NewUniverse(protocol FetchProtocol, selfURL string, opts ...UniverseOpt) *U
 
 	c := &Universe{
 		galaxies:   make(map[string]*Galaxy),
-		peerPicker: newPeerPicker(protocol, selfURL, options.hashOpts),
+		peerPicker: newPeerPicker(protocol, selfID, options.hashOpts),
 		recorder:   options.recorder,
 	}
 
@@ -114,8 +114,8 @@ func NewUniverse(protocol FetchProtocol, selfURL string, opts ...UniverseOpt) *U
 // NewUniverseWithOpts is a deprecated constructor for the Universe object that
 // defines a non-default hash function and number of replicas.  Please use
 // `NewUniverse` with the `WithHashOpts` option instead.
-func NewUniverseWithOpts(protocol FetchProtocol, selfURL string, options *HashOptions) *Universe {
-	return NewUniverse(protocol, selfURL, WithHashOpts(options))
+func NewUniverseWithOpts(protocol FetchProtocol, selfID string, options *HashOptions) *Universe {
+	return NewUniverse(protocol, selfID, WithHashOpts(options))
 }
 
 // NewGalaxy creates a coordinated galaxy-aware BackendGetter from a
@@ -197,7 +197,7 @@ func (universe *Universe) GetGalaxy(name string) *Galaxy {
 // Each PeerURL value should be a valid base URL,
 // for example "example.net:8000".
 func (universe *Universe) Set(peerURLs ...string) error {
-	return universe.peerPicker.set(peerURLs...)
+	return universe.peerPicker.setURLs(peerURLs...)
 }
 
 // Shutdown closes all open fetcher connections

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/vimeo/go-clocks v1.1.2
 	go.opencensus.io v0.22.5
+	golang.org/x/sync v0.1.0
 	google.golang.org/grpc v1.35.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/peers.go
+++ b/peers.go
@@ -29,6 +29,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/vimeo/galaxycache/consistenthash"
 )
 
@@ -48,9 +50,11 @@ type RemoteFetcher interface {
 // peers, and a map of RemoteFetchers to those peers
 type PeerPicker struct {
 	fetchingProtocol FetchProtocol
-	selfURL          string
-	peers            *consistenthash.Map
-	fetchers         map[string]RemoteFetcher
+	selfID           string
+	includeSelf      bool
+	peerIDs          *consistenthash.Map
+	fetchers         map[string]RemoteFetcher // keyed by ID
+	mapGen           peerSetGeneration
 	mu               sync.RWMutex
 	opts             HashOptions
 }
@@ -68,11 +72,12 @@ type HashOptions struct {
 }
 
 // Creates a peer picker; called when creating a new Universe
-func newPeerPicker(proto FetchProtocol, selfURL string, options *HashOptions) *PeerPicker {
+func newPeerPicker(proto FetchProtocol, selfID string, options *HashOptions) *PeerPicker {
 	pp := &PeerPicker{
 		fetchingProtocol: proto,
-		selfURL:          selfURL,
+		selfID:           selfID,
 		fetchers:         make(map[string]RemoteFetcher),
+		includeSelf:      true,
 	}
 	if options != nil {
 		pp.opts = *options
@@ -80,7 +85,7 @@ func newPeerPicker(proto FetchProtocol, selfURL string, options *HashOptions) *P
 	if pp.opts.Replicas == 0 {
 		pp.opts.Replicas = defaultReplicas
 	}
-	pp.peers = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
+	pp.peerIDs = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
 	return pp
 }
 
@@ -89,58 +94,221 @@ func newPeerPicker(proto FetchProtocol, selfURL string, options *HashOptions) *P
 func (pp *PeerPicker) pickPeer(key string) (RemoteFetcher, bool) {
 	pp.mu.Lock()
 	defer pp.mu.Unlock()
-	if URL := pp.peers.Get(key); URL != "" && URL != pp.selfURL {
+	if URL := pp.peerIDs.Get(key); URL != "" && URL != pp.selfID {
 		peer, ok := pp.fetchers[URL]
 		return peer, ok
 	}
 	return nil, false
 }
 
-func (pp *PeerPicker) set(peerURLs ...string) error {
-	pp.mu.Lock()
-	defer pp.mu.Unlock()
+// setURLs assumes that peerURL == peerID (legacy reasons)
+func (pp *PeerPicker) setURLs(peerURLs ...string) error {
+	peers := make([]Peer, len(peerURLs))
+	for i, url := range peerURLs {
+		peers[i] = Peer{URI: url, ID: url}
+	}
+	return pp.set(peers...)
+}
+
+// Peer is an ID and ip:port/url tuple for a specific peer
+type Peer struct {
+	// Unique ID for this peer (e.g. in k8s may be a pod name)
+	ID string
+	// URI or URL that the registered PeerFetcher can connect to
+	// URI should be a valid base URL,
+	// for example "example.net:8000" or "10.32.54.231:8123".
+	URI string
+}
+
+type peerSetGeneration uint64
+
+type peerSetDiff struct {
+	added        []Peer
+	removed      map[string]struct{}
+	selfIncluded bool
+	generation   peerSetGeneration
+}
+
+func (pp *PeerPicker) diffAbsolutePeers(peers []Peer) peerSetDiff {
+	pp.mu.RLock()
+	defer pp.mu.RUnlock()
 	currFetchers := make(map[string]struct{})
 
 	for url := range pp.fetchers {
 		currFetchers[url] = struct{}{}
 	}
 
-	for _, url := range peerURLs {
-		// open a new fetcher if there is currently no peer at url
-		if _, ok := pp.fetchers[url]; !ok {
-			newFetcher, err := pp.fetchingProtocol.NewFetcher(url)
-			if err != nil {
-				return err
-			}
-			pp.fetchers[url] = newFetcher
+	selfIncluded := false
+	newPeers := make([]Peer, 0, len(peers))
+	for _, peer := range peers {
+		if peer.ID == pp.selfID {
+			selfIncluded = true
+
+			continue
 		}
-		delete(currFetchers, url)
+		// open a new fetcher if there is currently no peer at url
+		// also skip the self ID
+		if _, ok := pp.fetchers[peer.ID]; !ok {
+			newPeers = append(newPeers, peer)
+			continue
+		}
+		delete(currFetchers, peer.ID)
 	}
 
-	for url := range currFetchers {
-		err := pp.fetchers[url].Close()
-		delete(pp.fetchers, url)
-		if err != nil {
-			return err
-		}
+	return peerSetDiff{
+		added:        newPeers,
+		removed:      currFetchers,
+		selfIncluded: selfIncluded,
+		generation:   pp.mapGen,
 	}
-	pp.peers = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
-	pp.peers.Add(peerURLs...)
-	return nil
+}
+
+// if nil, false is returned, there's a version mismatch
+// newFetchers should match indices in diff.added
+func (pp *PeerPicker) updatePeers(diff peerSetDiff, newFetchers []RemoteFetcher) ([]RemoteFetcher, bool) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	if diff.generation != pp.mapGen {
+		return nil, false
+	}
+	pp.includeSelf = diff.selfIncluded
+	// be optimistic: assume that we didn't race with anything. (we can do
+	// some extra allocations in the uncommon/racy case)
+	toClose := make([]RemoteFetcher, 0, len(diff.removed))
+	for i, fetcher := range newFetchers {
+		if _, ok := pp.fetchers[diff.added[i].ID]; ok {
+			toClose = append(toClose, fetcher)
+			continue
+		}
+		pp.fetchers[diff.added[i].ID] = fetcher
+	}
+
+	for remID := range diff.removed {
+		if fetcher, ok := pp.fetchers[remID]; ok {
+			toClose = append(toClose, fetcher)
+		}
+		delete(pp.fetchers, remID)
+	}
+
+	pp.regenerateHashringLocked()
+
+	return toClose, true
+}
+
+func (pp *PeerPicker) set(peers ...Peer) error {
+	loopPersistentFetchers := map[string]RemoteFetcher{}
+	defer func() {
+		for _, f := range loopPersistentFetchers {
+			f.Close()
+		}
+	}()
+	for {
+		diff := pp.diffAbsolutePeers(peers)
+
+		newfetchers := make([]RemoteFetcher, len(diff.added))
+		dialEG := errgroup.Group{}
+		for i, peerIter := range diff.added {
+			if f, ok := loopPersistentFetchers[peerIter.ID]; ok {
+				newfetchers[i] = f
+				delete(loopPersistentFetchers, peerIter.ID)
+				continue
+			}
+			peer := peerIter
+			i := i
+			dialEG.Go(func() error {
+				newFetcher, err := pp.fetchingProtocol.NewFetcher(peer.URI)
+				if err != nil {
+					return err
+				}
+				newfetchers[i] = newFetcher
+				return nil
+			})
+		}
+		if dialErr := dialEG.Wait(); dialErr != nil {
+			// NB: as of writing: we shouldn't get here in any real case as
+			// neither the HTTP nor the gRPC RemoteFetcher implementations
+			// actually do work when first constructed.
+			for _, fetcher := range newfetchers {
+				if fetcher == nil {
+					continue
+				}
+				fetcher.Close()
+			}
+			return fmt.Errorf("failed to dial at least one backend: %w", dialErr)
+		}
+
+		// regenerate the hashring before we try to close any of the fetchers
+		// so if they fail we don't end up with a hashring that's inconsistent
+		// with the set of fetchers.
+		rmFetchers, updated := pp.updatePeers(diff, newfetchers)
+		if !updated {
+			// Stash all the fetchers that we've already opened before looping
+			for i, fetcher := range newfetchers {
+				loopPersistentFetchers[diff.added[i].ID] = fetcher
+			}
+			continue
+		}
+
+		// if there's 0 or 1 to close, just iterate.
+		// if there are more, we'll spin up goroutines and use an errgroup
+		// (more for error-handling than efficiency)
+		if len(rmFetchers) < 2 {
+			for _, fetcher := range rmFetchers {
+				err := fetcher.Close()
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		closeEG := errgroup.Group{}
+		for _, fetcher := range rmFetchers {
+			f := fetcher
+			closeEG.Go(func() error {
+				if closeErr := f.Close(); closeErr != nil {
+					return fmt.Errorf("failed to close RemoteFetcher: %w", closeErr)
+				}
+				return nil
+			})
+		}
+		if closeErr := closeEG.Wait(); closeErr != nil {
+			return fmt.Errorf("failed to close fetcher(s): %w", closeErr)
+		}
+		return nil
+	}
+}
+
+func (pp *PeerPicker) regenerateHashringLocked() {
+	selfAdj := 0
+	if pp.includeSelf {
+		selfAdj = 1
+	}
+
+	newPeerIDs := make([]string, selfAdj, len(pp.fetchers)+selfAdj)
+	if pp.includeSelf {
+		newPeerIDs[0] = pp.selfID
+	}
+	for id := range pp.fetchers {
+		newPeerIDs = append(newPeerIDs, id)
+	}
+
+	// the consistenthash ring doesn't support removals so regenerate!
+	pp.peerIDs = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
+	pp.peerIDs.Add(newPeerIDs...)
+	pp.mapGen++
+}
+
+func (pp *PeerPicker) setIncludeSelf(inc bool) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	pp.includeSelf = inc
+	pp.regenerateHashringLocked()
 }
 
 func (pp *PeerPicker) shutdown() error {
-	errs := []error{}
-	for _, fetcher := range pp.fetchers {
-		err := fetcher.Close()
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to close: %v", errs)
-	}
-	return nil
+	pp.setIncludeSelf(false)
+	// Clear out all the existing peers
+	return pp.set()
 }
 
 // FetchProtocol defines the chosen fetching protocol to peers (namely

--- a/peers_test.go
+++ b/peers_test.go
@@ -1,0 +1,281 @@
+package galaxycache
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestPeers tests to ensure that an instance with given hash
+// function results in the expected number of gets both locally and into each other peer
+func TestPeersIncremental(t *testing.T) {
+
+	hashOpts := &HashOptions{
+		Replicas: 2,
+		HashFn:   nil,
+	}
+
+	type addRemoveStep struct {
+		add           []Peer
+		remove        []string
+		expectedPeers []Peer // don't include self (covered by includeSelf)
+		parallel      bool   // step should be split up and run in parallel
+		expectFailAdd bool
+		expectFailRm  bool
+		includeSelf   bool
+		setIncSelf    bool
+	}
+
+	const selfID = "selfImpossibleFetcher"
+	testCases := []struct {
+		name        string
+		initFunc    func(testProtocol *TestProtocol)
+		cacheSize   int64
+		includeSelf bool
+		steps       []addRemoveStep
+	}{
+		{
+			name:      "base_add_remove_serial",
+			initFunc:  func(*TestProtocol) {},
+			cacheSize: 1 << 20,
+			steps: []addRemoveStep{
+				{
+					add:           []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}},
+					remove:        []string{},
+					expectedPeers: []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true, // include self, but don't alter the default
+					setIncSelf:    false,
+				},
+				{
+					add:           []Peer{},
+					remove:        []string{"fizzlebat3", "fizzleboat3"}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true, // include self, but don't alter the default
+					setIncSelf:    false,
+				},
+				{
+					add:           []Peer{},
+					remove:        []string{}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true,
+					setIncSelf:    true,
+				},
+				{
+					add:           []Peer{},
+					remove:        []string{}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   false,
+					setIncSelf:    true,
+				},
+				{
+					add:           []Peer{},
+					remove:        []string{}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true,
+					setIncSelf:    true,
+				},
+			},
+		},
+		{
+			name:      "base_add_parallel",
+			initFunc:  func(*TestProtocol) {},
+			cacheSize: 1 << 20,
+			steps: []addRemoveStep{
+				{
+					add:           []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}, {ID: "fizzlebat5", URI: "fizzleboot5"}},
+					remove:        []string{},
+					expectedPeers: []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}, {ID: "fizzlebat5", URI: "fizzleboot5"}},
+					parallel:      true,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true, // include self, but don't alter the default
+					setIncSelf:    false,
+				},
+				{
+					add:           []Peer{},
+					remove:        []string{"fizzlebat3", "fizzleboat3"}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}, {ID: "fizzlebat5", URI: "fizzleboot5"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true, // include self, but don't alter the default
+					setIncSelf:    false,
+				},
+			},
+		},
+		{
+			name:      "one_peer_down",
+			cacheSize: 1 << 20,
+			initFunc: func(proto *TestProtocol) {
+				proto.dialFails = map[string]struct{}{"fizzleboot3": {}}
+			},
+			steps: []addRemoveStep{
+				{
+					add:           []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}},
+					remove:        []string{},
+					expectedPeers: []Peer{},
+					parallel:      false,
+					expectFailAdd: true,
+					expectFailRm:  false,
+					includeSelf:   true, // include self, but don't alter the default
+					setIncSelf:    false,
+				},
+				{
+					add:           []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					remove:        []string{},
+					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true, // include self, but don't alter the default
+					setIncSelf:    false,
+				},
+				{
+					add:           []Peer{},
+					remove:        []string{"fizzlebat3", "fizzleboat3"}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					parallel:      false,
+					expectFailAdd: false,
+					expectFailRm:  false,
+					includeSelf:   true, // include self, but don't alter the default
+					setIncSelf:    false,
+				},
+			},
+		},
+	}
+
+	for _, itbl := range testCases {
+		tbl := itbl
+
+		t.Run(tbl.name, func(t *testing.T) {
+			t.Parallel()
+			// instantiate test fetchers with the test protocol
+			testproto := TestProtocol{
+				TestFetchers: make(map[string]*TestFetcher),
+			}
+
+			checkErr := func(expErr bool, addErr error, opName string, stepIdx, opIdx int) {
+				t.Helper()
+				if expErr {
+					if addErr == nil {
+						t.Errorf("error expected at step %d (%dth %s) (got nil)",
+							stepIdx, opIdx, opName)
+					}
+				} else if addErr != nil {
+					t.Errorf("error %sing peer at step %d (%dth %s): %s",
+						opName, stepIdx, stepIdx, opName, addErr)
+				}
+			}
+
+			u := NewUniverseWithOpts(&testproto, selfID, hashOpts)
+
+			tbl.initFunc(&testproto)
+
+			for si, step := range tbl.steps {
+				if step.setIncSelf {
+					u.SetIncludeSelf(step.includeSelf)
+				}
+				if !step.parallel {
+					for z, p := range step.add {
+						addErr := u.AddPeer(p)
+						// for now; assume that all adds for the step will fail if any of them
+						// will
+						checkErr(step.expectFailAdd, addErr, "add", z, si)
+					}
+					if len(step.remove) > 0 {
+						removeErr := u.RemovePeers(step.remove...)
+						checkErr(step.expectFailRm, removeErr, "remove", 0, si)
+					}
+				} else {
+					// unbuffered channel that we'll close after all goroutines are spun up to
+					// ensure they all run at roughly the same time
+					gate := make(chan struct{})
+					wg := sync.WaitGroup{}
+					for iz, ip := range step.add {
+						wg.Add(1)
+						go func(i int, peer Peer) {
+							defer wg.Done()
+							<-gate
+							addErr := u.AddPeer(peer)
+							// for now; assume that all parallel adds for the step will fail
+							// if any of them will
+							checkErr(step.expectFailAdd, addErr, "add", i, si)
+						}(iz, ip)
+					}
+					for iz, ip := range step.remove {
+						wg.Add(1)
+						go func(i int, peer string) {
+							defer wg.Done()
+							<-gate
+							addErr := u.RemovePeers(peer)
+							// for now; assume that all parallel adds for the step will fail
+							// if any of them will
+							checkErr(step.expectFailRm, addErr, "remove", i, si)
+						}(iz, ip)
+					}
+					close(gate)
+					wg.Wait()
+				}
+
+				allPeersSlice := u.peerPicker.peerIDs.GetReplicated("a", 10)
+				allPeers := make(map[string]struct{}, len(allPeersSlice))
+				for _, pn := range allPeersSlice {
+					allPeers[pn] = struct{}{}
+				}
+
+				fetcherNames := make(map[string]struct{}, len(u.peerPicker.fetchers))
+				fetcherURIs := make(map[string]struct{}, len(u.peerPicker.fetchers))
+				for fn, f := range u.peerPicker.fetchers {
+					fetcherNames[fn] = struct{}{}
+					fetcherURIs[f.(*TestFetcher).uri] = struct{}{}
+				}
+
+				for _, expPeer := range step.expectedPeers {
+					if _, ok := allPeers[expPeer.ID]; !ok {
+						t.Errorf("missing peer %q from hashring at step %d", expPeer.ID, si)
+					}
+					delete(allPeers, expPeer.ID)
+					if _, ok := fetcherNames[expPeer.ID]; !ok {
+						t.Errorf("missing peer %q from fetchers map keys at step %d", expPeer.ID, si)
+					}
+					delete(fetcherNames, expPeer.ID)
+					if _, ok := fetcherURIs[expPeer.URI]; !ok {
+						t.Errorf("missing peer %q (URI %q) from fetchers values at step %d",
+							expPeer.ID, expPeer.URI, si)
+					}
+					delete(fetcherURIs, expPeer.URI)
+				}
+				if step.includeSelf {
+					if _, ok := allPeers[selfID]; !ok {
+						t.Errorf("missing self entry in hashring at step %d", si)
+					}
+					delete(allPeers, selfID)
+				}
+				if len(allPeers) > 0 {
+					t.Errorf("unexpected peer(s) in hashring at step %d: %v", si, allPeers)
+				}
+				if len(fetcherNames) > 0 {
+					t.Errorf("unexpected peer(s) in fetcher-map at step %d: %v", si, fetcherNames)
+				}
+				if len(fetcherURIs) > 0 {
+					t.Errorf("unexpected peer(s)' URI(s) in fetcher-map at step %d: %v", si, fetcherURIs)
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Many possible users of galaxycache are running in environments where it's most convenient to manage peers differently than we allow today.

Most notably, the existing scheme uses the URI for each peer as its ID, and only exposes a `Set()` method on the `Universe` for updating the entire set of peers at once.

This scheme is problematic for two reasons:
 1) Many libraries (notably (github.com/vimeo/k8swatcher)[https://github.com/vimeo/k8swatcher]) provide an incremental change-stream, thus forcing the client to aggregate a set of deltas into a current state-set and provide that
 2) Mixing the ID in the consistent-hash ring and the URI is limiting. Sometimes it's convenient to change the addressing mode for the peers between versions, and since URIs may include ports, if a user needs to change which port is used by a peer they have a bunch of awkward options to avoid distributed deadlocks during the transition.

This PR adds incremental fixes some bugs that could lead to inconsistent states if a connection failed, and parallelizes connections/disconnects.
Additionally, it refactors things so the `Set()` method doesn't hold the main lock on the `PeerPicker` while it does blocking work.

To support incremental changes, add automatic insertion of the local instance (and a method to toggle that behavior).
Automatically toggle such inclusion when `Set()` is called to keep the current behavior.