### PR TITLE
add ListPeers method that returns universe's fetchers.

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -232,6 +232,11 @@ func (universe *Universe) RemovePeers(ids ...string) error {
 	return universe.peerPicker.remove(ids...)
 }
 
+// ListPeers returns Universe's remote fetchers map keyed by peer IDs
+func (universe *Universe) ListPeers() map[string]RemoteFetcher {
+	return universe.peerPicker.listPeers()
+}
+
 // Shutdown closes all open fetcher connections
 func (universe *Universe) Shutdown() error {
 	return universe.peerPicker.shutdown()

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -232,7 +232,8 @@ func (universe *Universe) RemovePeers(ids ...string) error {
 	return universe.peerPicker.remove(ids...)
 }
 
-// ListPeers returns Universe's remote fetchers map keyed by peer IDs
+// ListPeers returns a map of remote fetchers keyed by Peer ID,
+// useful for testing incremental changes to galaxycache peers.
 func (universe *Universe) ListPeers() map[string]RemoteFetcher {
 	return universe.peerPicker.listPeers()
 }

--- a/peers.go
+++ b/peers.go
@@ -396,9 +396,15 @@ func (pp *PeerPicker) remove(ids ...string) error {
 }
 
 func (pp *PeerPicker) listPeers() map[string]RemoteFetcher {
-	pp.mu.Lock()
-	defer pp.mu.Unlock()
-	fetchers := pp.fetchers
+	pp.mu.RLock()
+	defer pp.mu.RUnlock()
+
+	// deep copy of pp.fetchers map.
+	fetchers := make(map[string]RemoteFetcher)
+	for p, f := range pp.fetchers {
+		fetchers[p] = f
+	}
+
 	return fetchers
 }
 

--- a/peers.go
+++ b/peers.go
@@ -395,6 +395,13 @@ func (pp *PeerPicker) remove(ids ...string) error {
 	return eg.Wait()
 }
 
+func (pp *PeerPicker) listPeers() map[string]RemoteFetcher {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	fetchers := pp.fetchers
+	return fetchers
+}
+
 func (pp *PeerPicker) shutdown() error {
 	pp.setIncludeSelf(false)
 	// Clear out all the existing peers

--- a/peers.go
+++ b/peers.go
@@ -399,7 +399,7 @@ func (pp *PeerPicker) listPeers() map[string]RemoteFetcher {
 	pp.mu.RLock()
 	defer pp.mu.RUnlock()
 
-	// deep copy of fetchers map with size equal to length of pp.fetchers.
+	// copy of pp.fetchers map.
 	fetchers := make(map[string]RemoteFetcher, len(pp.fetchers))
 	for p, f := range pp.fetchers {
 		fetchers[p] = f

--- a/peers.go
+++ b/peers.go
@@ -399,8 +399,8 @@ func (pp *PeerPicker) listPeers() map[string]RemoteFetcher {
 	pp.mu.RLock()
 	defer pp.mu.RUnlock()
 
-	// deep copy of pp.fetchers map.
-	fetchers := make(map[string]RemoteFetcher)
+	// deep copy of fetchers map with size equal to length of pp.fetchers.
+	fetchers := make(map[string]RemoteFetcher, len(pp.fetchers))
 	for p, f := range pp.fetchers {
 		fetchers[p] = f
 	}

--- a/peers_test.go
+++ b/peers_test.go
@@ -244,6 +244,14 @@ func TestPeersIncremental(t *testing.T) {
 					fetcherURIs[f.(*TestFetcher).uri] = struct{}{}
 				}
 
+				allFetchers := u.peerPicker.listPeers()
+				allPeerIDs := make(map[string]struct{}, len(allFetchers))
+				allFetcherURIs := make(map[string]struct{}, len(allFetchers))
+				for peerID, fetcher := range allFetchers {
+					allPeerIDs[peerID] = struct{}{}
+					allFetcherURIs[fetcher.(*TestFetcher).uri] = struct{}{}
+				}
+
 				for _, expPeer := range step.expectedPeers {
 					if _, ok := allPeers[expPeer.ID]; !ok {
 						t.Errorf("missing peer %q from hashring at step %d", expPeer.ID, si)
@@ -258,6 +266,17 @@ func TestPeersIncremental(t *testing.T) {
 							expPeer.ID, expPeer.URI, si)
 					}
 					delete(fetcherURIs, expPeer.URI)
+					// Checks for peer IDs and fetchers from listPeers method.
+					if _, ok := allPeerIDs[expPeer.ID]; !ok {
+						t.Errorf("missing peer %q from copy of fetchers map keys at step %d",
+							expPeer.ID, si)
+					}
+					delete(allPeerIDs, expPeer.ID)
+					if _, ok := allFetcherURIs[expPeer.URI]; !ok {
+						t.Errorf("missing peer %q (URI %q) from copy of fetchers values at step %d",
+							expPeer.ID, expPeer.URI, si)
+					}
+					delete(allFetcherURIs, expPeer.URI)
 				}
 				if step.includeSelf {
 					if _, ok := allPeers[selfID]; !ok {
@@ -273,6 +292,14 @@ func TestPeersIncremental(t *testing.T) {
 				}
 				if len(fetcherURIs) > 0 {
 					t.Errorf("unexpected peer(s)' URI(s) in fetcher-map at step %d: %v", si, fetcherURIs)
+				}
+				// Checks for peer IDs and fetchers from listPeers method.
+				if len(allPeerIDs) > 0 {
+					t.Errorf("unexpected peer(s) in copy of fetcher-map at step %d: %v", si, allPeerIDs)
+				}
+				if len(allFetcherURIs) > 0 {
+					t.Errorf("unexpected peer(s)' URI(s) in copy of fetcher-map at step %d: %v",
+						si, allFetcherURIs)
 				}
 			}
 		})

--- a/peers_test.go
+++ b/peers_test.go
@@ -244,7 +244,7 @@ func TestPeersIncremental(t *testing.T) {
 					fetcherURIs[f.(*TestFetcher).uri] = struct{}{}
 				}
 
-				allFetchers := u.peerPicker.listPeers()
+				allFetchers := u.ListPeers()
 				allPeerIDs := make(map[string]struct{}, len(allFetchers))
 				allFetcherURIs := make(map[string]struct{}, len(allFetchers))
 				for peerID, fetcher := range allFetchers {


### PR DESCRIPTION
Currently there is no way for apps using galaxycache to unit test peers when using AddPeer/RemovePeer methods for incremental changes. ListPeers method returns fetchers map keyed by peer ID can be used to verify the peers and its address by using a RemoteFetcher implementation that provides required information. 