### PR TITLE
Allow the Go Workflow to be Triggered Manually

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [push]
+on: [push, workflow_dispatch]
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Apparently we need
[workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) to make this work.