### PR TITLE
lru: consolidate LRU for go 1.20+ 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.17, 1.18, '1.19']
+        goversion: [1.17, 1.18, '1.19', '1.20']
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
         uses: actions/setup-go@v3
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: gofmt
-        if: ${{matrix.goversion == '1.19'}}
+        if: ${{matrix.goversion == '1.20'}}
         run: |
           [[ -z  $(gofmt -l $(find . -name '*.go') ) ]]
 
@@ -43,9 +43,9 @@ jobs:
           GO111MODULE: on
         run: go test -race -mod=readonly -count 2 ./...
 
-        # Run all consistenthash Fuzz tests for 30s with go 1.19
+        # Run all consistenthash Fuzz tests for 30s with go 1.20
       - name: Fuzz Consistent-Hash
-        if: ${{matrix.goversion == '1.19'}}
+        if: ${{matrix.goversion == '1.20'}}
         env:
           GO111MODULE: on
         run: go test -fuzz=. -fuzztime=30s ./consistenthash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vimeo/galaxycache
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golang/protobuf v1.4.3

--- a/lru/lru.go
+++ b/lru/lru.go
@@ -1,3 +1,5 @@
+//go:build !go1.20
+
 /*
 Copyright 2013 Google Inc.
 

--- a/lru/lru_go120.go
+++ b/lru/lru_go120.go
@@ -1,0 +1,34 @@
+//go:build go1.20
+
+/*
+Copyright 2023 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package lru
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+// This is a compatibility alias for TypedCache[Key,any]
+type Cache = TypedCache[Key, any]
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return TypedNew[Key, any](maxEntries)
+}


### PR DESCRIPTION
With Go 1.20+, interface-types become capable of satisfying comparable
constraints (with a runtime-check/panic). Thus it becomes possible to
deduplicate the two public types in the lru package.

Use build-tags to preserve compatibility with versions below go 1.20 by
preserving the legacy implementation.