### PR TITLE
latency distribution for local gets per galaxy using GetterFunc

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -613,6 +613,10 @@ func (g *Galaxy) load(ctx context.Context, key string, dest Codec) (value valWit
 }
 
 func (g *Galaxy) getLocally(ctx context.Context, key string, dest Codec) ([]byte, error) {
+	startTime := time.Now()
+	defer func() {
+		stats.RecordWithTags(ctx, nil, MGetterFuncLatencyMilliseconds.M(sinceInMilliseconds(startTime)))
+	}()
 	err := g.getter.Get(ctx, key, dest)
 	if err != nil {
 		return nil, err

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -615,7 +615,7 @@ func (g *Galaxy) load(ctx context.Context, key string, dest Codec) (value valWit
 func (g *Galaxy) getLocally(ctx context.Context, key string, dest Codec) ([]byte, error) {
 	startTime := time.Now()
 	defer func() {
-		stats.RecordWithTags(ctx, nil, MGetterFuncLatencyMilliseconds.M(sinceInMilliseconds(startTime)))
+		g.recordStats(ctx, nil, MGetterFuncLatencyMilliseconds.M(sinceInMilliseconds(startTime)))
 	}()
 	err := g.getter.Get(ctx, key, dest)
 	if err != nil {

--- a/observability.go
+++ b/observability.go
@@ -55,6 +55,8 @@ var (
 
 	MCacheSize    = stats.Int64("galaxycache/cache_bytes", "The number of bytes used for storing Keys and Values in the cache", stats.UnitBytes)
 	MCacheEntries = stats.Int64("galaxycache/cache_entries", "The number of entries in the cache", stats.UnitDimensionless)
+
+	MGetterFuncLatencyMilliseconds = stats.Float64("galaxycache/getterfunc_latency", "Local getter function latency in milliseconds", stats.UnitMilliseconds)
 )
 
 var (
@@ -90,6 +92,8 @@ var AllViews = []*view.View{
 	{Measure: MRoundtripLatencyMilliseconds, TagKeys: []tag.Key{GalaxyKey}, Aggregation: defaultMillisecondsDistribution},
 	{Measure: MCacheSize, TagKeys: []tag.Key{GalaxyKey, CacheTypeKey}, Aggregation: view.LastValue()},
 	{Measure: MCacheEntries, TagKeys: []tag.Key{GalaxyKey, CacheTypeKey}, Aggregation: view.LastValue()},
+
+	{Measure: MGetterFuncLatencyMilliseconds, TagKeys: []tag.Key{GalaxyKey}, Aggregation: defaultMillisecondsDistribution},
 }
 
 func sinceInMilliseconds(start time.Time) float64 {


### PR DESCRIPTION
Tracks latency for local gets from backend using GetterFunc when there is miss for object in maincache/hotcache.