### PR TITLE
protocodec: make a few tweaks to allow inlining

### DIFF
--- a/protocodec/galaxywrap_v2.go
+++ b/protocodec/galaxywrap_v2.go
@@ -10,11 +10,11 @@ import (
 
 // GalaxyGet is a simple wrapper around a Galaxy.Get method-call that takes
 // care of constructing the protocodec.CodecV2, etc. (making the interface more idiomatic for Go)
-func GalaxyGet[C any, T pointerMessage[C]](ctx context.Context, g *galaxycache.Galaxy, key string) (T, error) {
-	pc := NewV2[C, T]()
-	getErr := g.Get(ctx, key, &pc)
+func GalaxyGet[C any, T pointerMessage[C]](ctx context.Context, g *galaxycache.Galaxy, key string) (m T, getErr error) {
+	pc := CodecV2[C, T]{}
+	getErr = g.Get(ctx, key, &pc)
 	if getErr != nil {
-		return nil, getErr
+		return // use named return values to bring the inlining cost down
 	}
-	return pc.Get(), nil
+	return pc.msg, nil
 }


### PR DESCRIPTION
protocodec.GalaxyGet is particularly hot, and trivial so it should get
inlined. Make a few tweaks to allow inlining. (bringing the cost down
below the magic 80 number in the go compiler)

Similarly, split up protocodec.backendGetterV2.Get to allow inlining of
the fast path. (Amusingly, this also allows the new setSlow to inline,
but that wasn't the goal)
