### PR TITLE
actions: add go 1.23 to test matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.17, 1.18, '1.19', '1.20', '1.21', '1.22']
+        goversion: [1.17, 1.18, '1.19', '1.20', '1.21', '1.22', '1.23']
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
         uses: actions/setup-go@v3
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: gofmt
-        if: ${{matrix.goversion == '1.22'}}
+        if: ${{matrix.goversion == '1.23'}}
         run: |
           [[ -z  $(gofmt -l $(find . -name '*.go') ) ]]
 


### PR DESCRIPTION
Go 1.23 is now commonplace. Include it in the test matrix.
