### PR TITLE
jsoncodec: add a codec impl using encoding/json

### DIFF
--- a/jsoncodec/backend_getter.go
+++ b/jsoncodec/backend_getter.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsoncodec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/vimeo/galaxycache"
+)
+
+// BackendGetter is an adapter that implements galaxycache.BackendGetter
+// (it wraps an unexported type because type-inference is much better on function-calls)
+func BackendGetter[T any](f func(ctx context.Context, key string) (T, error)) galaxycache.BackendGetter {
+	return backendGetter[T](f)
+}
+
+// backendGetter is an adapter type that implements galaxycache.BackendGetter
+type backendGetter[T any] func(ctx context.Context, key string) (T, error)
+
+// Get populates dest with the value identified by key
+// The returned data must be unversioned. That is, key must
+// uniquely describe the loaded data, without an implicit
+// current time, and without relying on cache expiration
+// mechanisms.
+func (b backendGetter[T]) Get(ctx context.Context, key string, dest galaxycache.Codec) error {
+	out, bgErr := b(ctx, key)
+	if bgErr != nil {
+		return bgErr
+	}
+	if d, ok := dest.(*Codec[T]); ok {
+		d.Set(out)
+		return nil
+	}
+	return b.setSlow(out, dest)
+}
+
+func (b backendGetter[T]) setSlow(out T, dest galaxycache.Codec) error {
+	vs, mErr := json.Marshal(out)
+	if mErr != nil {
+		return fmt.Errorf("failed to marshal value as bytes: %w", mErr)
+	}
+
+	if uErr := dest.UnmarshalBinary(vs); uErr != nil {
+		return fmt.Errorf("destination codec (type %T) Unmarshal failed: %w", dest, uErr)
+	}
+	return nil
+}

--- a/jsoncodec/backend_getter_test.go
+++ b/jsoncodec/backend_getter_test.go
@@ -1,0 +1,106 @@
+package jsoncodec_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/vimeo/galaxycache"
+	"github.com/vimeo/galaxycache/jsoncodec"
+)
+
+type testMessage struct {
+	Name string
+	City string
+}
+
+// Test of common-good-case
+func TestBackendGetterGood(t *testing.T) {
+	beGood := func(ctx context.Context, key string) (testMessage, error) {
+		return testMessage{
+			Name: "TestName",
+			City: "TestCity",
+		}, nil
+	}
+
+	be := jsoncodec.BackendGetter(beGood)
+
+	ctx := context.Background()
+
+	// test with a proto codec passed (local common-case)
+	{
+		pc := jsoncodec.Codec[testMessage]{}
+
+		if getErr := be.Get(ctx, "foobar", &pc); getErr != nil {
+			t.Errorf("noop Get call failed: %s", getErr)
+		}
+
+		pv := pc.Get()
+		if pv.City != "TestCity" {
+			t.Errorf("unexpected value for City: %v", pv.City)
+		}
+		if pv.Name != "TestName" {
+			t.Errorf("unexpected value for Name: %v", pv.Name)
+		}
+	}
+	// test with a ByteCodec to exercise the common-case when a remote-fetch is done
+	{
+		c := galaxycache.ByteCodec{}
+
+		if getErr := be.Get(ctx, "foobar", &c); getErr != nil {
+			t.Errorf("noop Get call failed: %s", getErr)
+		}
+
+		if len(c) < len("TestName")+len("TestCity") {
+			t.Errorf("marshaled bytes too short (less than sum of two string fields)")
+		}
+
+		pc := jsoncodec.Codec[testMessage]{}
+
+		if umErr := pc.UnmarshalBinary([]byte(c)); umErr != nil {
+			t.Errorf("failed to unmarshal bytes: %s", umErr)
+		}
+
+		pv := pc.Get()
+		if pv.City != "TestCity" {
+			t.Errorf("unexpected value for City: %v", pv.City)
+		}
+		if pv.Name != "TestName" {
+			t.Errorf("unexpected value for Name: %v", pv.Name)
+		}
+	}
+}
+
+func TestBackendGetterBad(t *testing.T) {
+	sentinel := errors.New("sentinel error")
+
+	beErrorer := func(ctx context.Context, key string) (*testMessage, error) {
+		return nil, fmt.Errorf("error: %w", sentinel)
+	}
+
+	be := jsoncodec.BackendGetter(beErrorer)
+
+	ctx := context.Background()
+
+	// test with a proto codec passed (local common-case)
+	{
+		pc := jsoncodec.Codec[testMessage]{}
+
+		if getErr := be.Get(ctx, "foobar", &pc); getErr == nil {
+			t.Errorf("noop Get call didn't fail")
+		} else if !errors.Is(getErr, sentinel) {
+			t.Errorf("Error from Get did not wrap/equal sentinel")
+		}
+	}
+	// test with a ByteCodec to exercise the common-case when a remote-fetch is done
+	{
+		c := galaxycache.ByteCodec{}
+
+		if getErr := be.Get(ctx, "foobar", &c); getErr == nil {
+			t.Errorf("noop Get call didn't fail")
+		} else if !errors.Is(getErr, sentinel) {
+			t.Errorf("Error from Get did not wrap/equal sentinel")
+		}
+	}
+}

--- a/jsoncodec/codec.go
+++ b/jsoncodec/codec.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jsoncodec provides some helpful wrappers and a core [Codec]
+// implementation to make using JSON payloads easy within systems using
+// Galaxycache.
+//
+// In general, it is recommended to use the
+// [github.com/vimeo/galaxycache/protocodec.CodecV2] codec if at all possible,
+// as protobuf generally provides lower overhead in both space and
+// proccessing-time, schemas that can evolve, and the ability to rename fields
+// as necessary.
+//
+// This package should *_not_* be used for caching protobuf message-types, it is
+// *_always_* better to use binary marshaling with
+// [github.com/vimeo/galaxycache/protocodec.CodecV2] in that case.
+package jsoncodec
+
+import (
+	"encoding/json"
+)
+
+// Codec wraps another type, providing a simple wrapper for clients that want to wrap JSON.
+//
+// Note: protocodec should generally be prefered for new deployments. This
+// implementation is provided to provide an easy way to insert Galaxycache into
+// systems that are already using JSON internally for the payloads they'll be working with.
+type Codec[T any] struct {
+	msg T
+}
+
+// MarshalBinary on a ProtoCodec returns the encoded proto message
+func (c *Codec[T]) MarshalBinary() ([]byte, error) {
+	return json.Marshal(&c.msg)
+}
+
+// UnmarshalBinary on a ProtoCodec unmarshals provided data into
+// the proto message
+func (c *Codec[T]) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, &c.msg)
+}
+
+// Get implies returns the internal protobuf message value
+func (c *Codec[T]) Get() *T {
+	return &c.msg
+}
+
+// Set bypasses Marshaling and lets you set the internal protobuf value
+func (c *Codec[T]) Set(v T) {
+	c.msg = v
+}

--- a/jsoncodec/codec_test.go
+++ b/jsoncodec/codec_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsoncodec_test
+
+import (
+	"testing"
+
+	"github.com/vimeo/galaxycache/jsoncodec"
+)
+
+func TestJSONCodec(t *testing.T) {
+	inProtoCodec := jsoncodec.Codec[testMessage]{}
+	inProtoCodec.Set(testMessage{
+		Name: "TestName",
+		City: "TestCity",
+	})
+
+	testMsgBytes, err := inProtoCodec.MarshalBinary()
+	if err != nil {
+		t.Errorf("Error marshaling from protoCodec: %s", err)
+	}
+	t.Logf("Marshaled Bytes: %q", string(testMsgBytes))
+
+	outProtoCodec := jsoncodec.Codec[testMessage]{}
+
+	if unmarshalErr := outProtoCodec.UnmarshalBinary(testMsgBytes); unmarshalErr != nil {
+		t.Errorf("Error unmarshaling: %s", unmarshalErr)
+	}
+
+	if *outProtoCodec.Get() != *inProtoCodec.Get() {
+		t.Errorf("UnmarshalBinary resulted in %+v; want %+v", *outProtoCodec.Get(), *inProtoCodec.Get())
+	}
+}

--- a/jsoncodec/galaxywrap.go
+++ b/jsoncodec/galaxywrap.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsoncodec
+
+import (
+	"context"
+
+	"github.com/vimeo/galaxycache"
+)
+
+// GalaxyGet is a simple wrapper around a Galaxy.Get method-call that takes
+// care of constructing the [Codec], etc. (making the interface more idiomatic for Go)
+func GalaxyGet[T any](ctx context.Context, g *galaxycache.Galaxy, key string) (m *T, getErr error) {
+	pc := Codec[T]{}
+	getErr = g.Get(ctx, key, &pc)
+	if getErr != nil {
+		return // use named return values to bring the inlining cost down
+	}
+	return &pc.msg, nil
+}


### PR DESCRIPTION
While protobuf is almost always a better choice for payload marshaling,
there are cases where galaxycache is being added at short-notice to
systems that already have canonical JSON representations. In that case,
defining a protobuf message-type for each Galaxy would delay the
benefits of having Galaxycache in-place.

Note: this is mostly a C&P of the protocodec's V2 types with a few
adjustments because we can be a bit less picky here.
