### PR TITLE
k8swatch: factor out body & IncludeSelf Management

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test k8swatch
         env:
           GO111MODULE: on
-        run: cd k8swatch && go test -mod=readonly ./...
+        run: cd k8swatch && go test -mod=readonly -count 2 ./...
 
       - name: Race Test
         env:
@@ -57,6 +57,14 @@ jobs:
         env:
           GO111MODULE: on
         run: cd k8swatch && go test -race -mod=readonly -count 2 ./...
+
+        # We ran the k8swatch tests with whatever galaxycache module version
+        # was set in that submodule's go.mod earlier. Run it with this version
+        # now. (using a go.work to create that linkage)
+      - name: Test k8swatch with go.work
+        env:
+          GO111MODULE: on
+        run: go work init . ./k8swatch && cd k8swatch && go test -mod=readonly -count 2 ./...
 
         # Run all consistenthash Fuzz tests for 30s with go 1.24
       - name: Fuzz Consistent-Hash

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 *.sw[op]
+go.work
+go.work.sum

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -207,15 +207,16 @@ func (universe *Universe) Set(peerURLs ...string) error {
 // SetPeers updates the Universe's list of peers (contained in the PeerPicker).
 // Each Peer's URI value should be a valid base URL, while the ID may be anything that's unique,
 // for example "example.net:8000".
-// If Set and SetPeers are mixed, the ID and URI fields must match.
+// If AddPeer, Set and SetPeers are mixed, the ID and URI fields must match.
 func (universe *Universe) SetPeers(peers ...Peer) error {
 	return universe.peerPicker.set(peers...)
 }
 
 // AddPeer updates the Universe's list of peers to include the passed peer (contained in the PeerPicker).
-// The Peer's URI value should be a valid base URL, while the ID may be anything that's unique,
-// for example "example.net:8000".
-// If Set and AddPeer are mixed, the ID and URI fields must match.
+// The Peer's URI value should be a valid base URL as understood by the RemoteFetcher implementation, while the ID may
+// be anything that's unique, for example "example.net:8000" (However, in k8s, it's recommended to use a pod name
+// (possibly with some qualification)).
+// If Set, SetPeers and AddPeer calls are mixed, the ID and URI fields must match.
 func (universe *Universe) AddPeer(peer Peer) error {
 	return universe.peerPicker.add(peer)
 }
@@ -223,6 +224,13 @@ func (universe *Universe) AddPeer(peer Peer) error {
 // SetIncludeSelf toggles the inclusion of the "self ID" for the universe in the PeerPicker's hash-ring
 func (universe *Universe) SetIncludeSelf(incSelf bool) {
 	universe.peerPicker.setIncludeSelf(incSelf)
+}
+
+// IncludeSelf returns a bool indicating whether the "self ID" for the universe is currently included in the
+// PeerPicker's hash-ring
+// This is generally not useful oustide of tests that need to verify whether events are being handled correctly.
+func (universe *Universe) IncludeSelf() bool {
+	return universe.peerPicker.includeSelfVal()
 }
 
 // RemovePeers updates the Universe's list of peers to remove the passed peers IDs (contained in the PeerPicker).
@@ -241,6 +249,12 @@ func (universe *Universe) ListPeers() map[string]RemoteFetcher {
 // Shutdown closes all open fetcher connections
 func (universe *Universe) Shutdown() error {
 	return universe.peerPicker.shutdown()
+}
+
+// SelfID returns the selfID that was passed to the constructor and is used for
+// self-identification in the hash-ring.
+func (universe *Universe) SelfID() string {
+	return universe.peerPicker.selfID
 }
 
 // HCStatsWithTime includes a time stamp along with the hotcache stats

--- a/k8swatch/k8swatch.go
+++ b/k8swatch/k8swatch.go
@@ -8,6 +8,18 @@ import (
 	"github.com/vimeo/k8swatcher"
 )
 
+func handlePodUpdate(u *galaxycache.Universe, event k8swatcher.PodEvent, port int, isReady bool, podIP *net.IPAddr) {
+	if podIP != nil && isReady {
+		addr := net.TCPAddr{IP: podIP.IP, Port: port}
+		u.AddPeer(galaxycache.Peer{
+			ID:  event.PodName(),
+			URI: addr.String(),
+		})
+	} else {
+		u.RemovePeers(event.PodName())
+	}
+}
+
 // UpdateCB returns a callback that's appropriate for incrementally
 // updating the set of peers based on events from [k8swatcher.PodWatcher].
 // The port should be the integer port-number on which this galaxycache
@@ -16,25 +28,9 @@ func UpdateCB(u *galaxycache.Universe, port int) k8swatcher.EventCallback {
 	return func(ctx context.Context, event k8swatcher.PodEvent) {
 		switch ut := event.(type) {
 		case *k8swatcher.CreatePod:
-			if ut.IP != nil && ut.IsReady() {
-				addr := net.TCPAddr{IP: ut.IP.IP, Port: port}
-				u.AddPeer(galaxycache.Peer{
-					ID:  ut.PodName(),
-					URI: addr.String(),
-				})
-			} else {
-				u.RemovePeers(ut.PodName())
-			}
+			handlePodUpdate(u, event, port, ut.IsReady(), ut.IP)
 		case *k8swatcher.ModPod:
-			if ut.IP != nil && ut.IsReady() {
-				addr := net.TCPAddr{IP: ut.IP.IP, Port: port}
-				u.AddPeer(galaxycache.Peer{
-					ID:  ut.PodName(),
-					URI: addr.String(),
-				})
-			} else {
-				u.RemovePeers(ut.PodName())
-			}
+			handlePodUpdate(u, event, port, ut.IsReady(), ut.IP)
 		case *k8swatcher.DeletePod:
 			u.RemovePeers(ut.PodName())
 		case *k8swatcher.InitialListComplete:

--- a/k8swatch/k8swatch.go
+++ b/k8swatch/k8swatch.go
@@ -6,7 +6,17 @@ import (
 
 	"github.com/vimeo/galaxycache"
 	"github.com/vimeo/k8swatcher"
+
+	k8score "k8s.io/api/core/v1"
 )
+
+func handleSelfUpdate(u *galaxycache.Universe, podDef *k8score.Pod) {
+	if podDef.DeletionTimestamp == nil {
+		return
+	}
+	// We're going down, remove ourselves from the hashring
+	u.SetIncludeSelf(false)
+}
 
 func handlePodUpdate(u *galaxycache.Universe, event k8swatcher.PodEvent, port int, isReady bool, podIP *net.IPAddr) {
 	if podIP != nil && isReady {
@@ -25,13 +35,34 @@ func handlePodUpdate(u *galaxycache.Universe, event k8swatcher.PodEvent, port in
 // The port should be the integer port-number on which this galaxycache
 // universe is registered with a gRPC server (or similar).
 func UpdateCB(u *galaxycache.Universe, port int) k8swatcher.EventCallback {
+	// Use a type-assert so we can handle some version skew with older
+	// versions of galaxycache (until we have a new release and update the
+	// k8swatch go.mod to require it)
+	isSelf := func(event k8swatcher.PodEvent) bool { return false }
+	if ui, ok := any(u).(interface{ SelfID() string }); ok {
+		selfID := ui.SelfID()
+		isSelf = func(event k8swatcher.PodEvent) bool { return event.PodName() == selfID }
+	}
 	return func(ctx context.Context, event k8swatcher.PodEvent) {
 		switch ut := event.(type) {
 		case *k8swatcher.CreatePod:
+			if isSelf(event) {
+				handleSelfUpdate(u, ut.Def)
+				return
+			}
 			handlePodUpdate(u, event, port, ut.IsReady(), ut.IP)
 		case *k8swatcher.ModPod:
+			if isSelf(event) {
+				handleSelfUpdate(u, ut.Def)
+				return
+			}
 			handlePodUpdate(u, event, port, ut.IsReady(), ut.IP)
 		case *k8swatcher.DeletePod:
+			if isSelf(event) {
+				// shouldn't happen, but handle it anyway
+				u.SetIncludeSelf(false)
+				return
+			}
 			u.RemovePeers(ut.PodName())
 		case *k8swatcher.InitialListComplete:
 			return

--- a/peers.go
+++ b/peers.go
@@ -361,6 +361,12 @@ func (pp *PeerPicker) regenerateHashringLocked() {
 	pp.mapGen++
 }
 
+func (pp *PeerPicker) includeSelfVal() bool {
+	pp.mu.RLock()
+	defer pp.mu.RUnlock()
+	return pp.includeSelf
+}
+
 func (pp *PeerPicker) setIncludeSelf(inc bool) {
 	pp.mu.Lock()
 	defer pp.mu.Unlock()


### PR DESCRIPTION
- **k8swatch: factor out common switch body**
  CreatePod and ModPod events are identical code, but operating on
  distinct structs. Pull the body out into an unexported free-function so
  we have one code-path to work with.
  

- **k8swatch: SetIncludeSelf management**
  Add a couple methods to the universe to support and add code to k8swatch
  that handle updates to the self pod-name.
  
  Due to the slight weirdness of changes that cross modules, we use a
  type-assert and progressive enhancement.
  
  After we cut a Galaxycache release with the new methods, we can update
  go.mod in the k8swatch submodule.
  