### PR TITLE
LRU fuzzing overhaul

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,6 +78,11 @@ jobs:
         env:
           GO111MODULE: on
         run: |
-          sed -e 's/const paranoidLL = false/const paranoidLL = true/' < lru/typed_ll.go > lru/typed_ll.go.new
-          mv lru/typed_ll.go.new lru/typed_ll.go
-          go test -race -mod=readonly -count 2 ./...
+          go test --tags=paranoidgcll -race -mod=readonly -count 2 ./...
+ 
+        # Run the lru Fuzz tests for 30s with go 1.24 (in paranoid mode)
+      - name: Fuzz Consistent-Hash
+        if: ${{matrix.goversion == '1.24'}}
+        env:
+          GO111MODULE: on
+        run: go test --tags=paranoidgcll -fuzz=. -fuzztime=30s ./lru

--- a/lru/paranoid_check_disabled.go
+++ b/lru/paranoid_check_disabled.go
@@ -1,0 +1,24 @@
+//go:build !paranoidgcll
+
+/*
+Copyright 2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lru
+
+// Default-disable paranoid checks so they get compiled out.
+// This file is build-tagged so these checks can easily be enabled or disabled.
+// The `paranoidgcll` build tag breaks down as "paranoid Galaxycache Linked List".
+const paranoidLL = false

--- a/lru/paranoid_check_enabled.go
+++ b/lru/paranoid_check_enabled.go
@@ -1,0 +1,24 @@
+//go:build paranoidgcll
+
+/*
+Copyright 2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lru
+
+// Default-disable paranoid checks so they get compiled out.
+// This file is build-tagged so these checks can easily be enabled or disabled.
+// The `paranoidgcll` build tag breaks down as "paranoid Galaxycache Linked List".
+const paranoidLL = true

--- a/lru/typed_ll.go
+++ b/lru/typed_ll.go
@@ -20,11 +20,6 @@ package lru
 
 import "fmt"
 
-// Default-disable paranoid checks so they get compiled out.
-// If this const is renamed/moved/updated make sure to update the sed
-// expression in the github action. (.github/workflows/go.yml)
-const paranoidLL = false
-
 // LinkedList using generics to reduce the number of heap objects
 // Used for the LRU stack in TypedCache
 type linkedList[T any] struct {

--- a/lru/typed_ll_weak.go
+++ b/lru/typed_ll_weak.go
@@ -23,11 +23,6 @@ import (
 	"weak"
 )
 
-// Default-disable paranoid checks so they get compiled out.
-// If this const is renamed/moved/updated make sure to update the sed
-// expression in the github action. (.github/workflows/go.yml)
-const paranoidLL = false
-
 // LinkedList using generics to reduce the number of heap objects
 // Used for the LRU stack in TypedCache
 // This implementation switches to using weak pointers when using go 1.24+ so


### PR DESCRIPTION
 - [lru: simplify paranoid GC Linked List testing](https://github.com/vimeo/galaxycache/commit/131a2a5cf6f220ffc7f955609f419c426103afd3)
    Move the `paranoidLL` constant to its own build-tagged files so we can
toggle which mode is active by setting a build-tag on the test instead
of having to use sed to modify the constant-value.

- [lru: rewrite FuzzTypedAddRemove](https://github.com/vimeo/galaxycache/commit/d90df581add58d9b7c7dda8509239b08d6d6a430)
 Vastly simplify FuzzTypedAddRemove by limiting the keyspace, and make it
more useful by providing triggers for running the GC in parallel.

  Use the two high-bits to select the operation and the low-6 bits the
key. (this eliminates the degree of freedom where the fuzzer picks
super-long keys, since it's effectively fuzzing the hash-table's
hash-function.)

  Unfortunately, this does cause the fuzzer to explore the control flow in
the Garbage Collector somewhat, (that's an unfortunate random walk),
but when working with weak pointers, you really do need the GC to run to
have any confidence that you didn't remove something you need.