### PR TITLE
consistenthash: split GetReplicated with go 1.23 range functions

### DIFF
--- a/consistenthash/consistenthash.go
+++ b/consistenthash/consistenthash.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"hash/crc32"
 	"sort"
-	"strconv"
 )
 
 // Hash maps the data to a uint32 hash-ring
@@ -57,32 +56,6 @@ func New(segsPerKey int, fn Hash) *Map {
 // IsEmpty returns true if there are no items available.
 func (m *Map) IsEmpty() bool {
 	return len(m.keyHashes) == 0
-}
-
-// Add adds some keys to the hashring, establishing ownership of segsPerKey
-// segments.
-func (m *Map) Add(keys ...string) {
-	for _, key := range keys {
-		m.keys[key] = struct{}{}
-		for i := 0; i < m.segsPerKey; i++ {
-			hash := m.hash([]byte(strconv.Itoa(i) + key))
-			// If there's a collision on a "replica" (segment-boundary), we only want
-			// the entry that sorts latest to get inserted (not the last one we saw).
-			//
-			// It doesn't matter how we reconcile collisions (the smallest would work
-			// just as well), we just need it to be insertion-order independent so all
-			// instances converge on the same hashmap.
-			if extKey, ok := m.hashMap[hash]; !ok {
-				// Only add another member for this hash-value if there shouldn't be
-				// one there already.
-				m.keyHashes = append(m.keyHashes, hash)
-			} else if extKey >= key {
-				continue
-			}
-			m.hashMap[hash] = key
-		}
-	}
-	sort.Slice(m.keyHashes, func(i, j int) bool { return m.keyHashes[i] < m.keyHashes[j] })
 }
 
 // Get gets the closest item in the hash to the provided key.
@@ -143,30 +116,4 @@ func (m *Map) idxedKeyReplica(key string, replica int) uint32 {
 
 	idxHashKey := append([]byte(key), idxSuffixBuf[:vIntLen+2]...)
 	return m.hash(idxHashKey)
-}
-
-// GetReplicated gets the closest item in the hash to a deterministic set of
-// keyReplicas variations of the provided key.
-// The returned set of segment-owning keys is dedup'd, and collisions are
-// resolved by traversing backwards in the hash-ring to find an unused
-// owning-key.
-func (m *Map) GetReplicated(key string, keyReplicas int) []string {
-	if m.IsEmpty() {
-		return []string{}
-	}
-	out := make([]string, 0, keyReplicas)
-	segOwners := make(map[string]struct{}, keyReplicas)
-
-	for i := 0; i < keyReplicas && len(out) < len(m.keys); i++ {
-		h := m.idxedKeyReplica(key, i)
-		segIdx, _, owner := m.findSegmentOwner(h)
-		for _, present := segOwners[owner]; present; _, present = segOwners[owner] {
-			// this may overflow, which is fine.
-			segIdx, _, owner = m.nextSegmentOwner(segIdx)
-		}
-		segOwners[owner] = struct{}{}
-		out = append(out, owner)
-	}
-
-	return out
 }

--- a/consistenthash/map_norangefunc.go
+++ b/consistenthash/map_norangefunc.go
@@ -1,0 +1,76 @@
+//go:build !go1.23
+
+/*
+Copyright 2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consistenthash
+
+import (
+	"sort"
+	"strconv"
+)
+
+// Add adds some keys to the hashring, establishing ownership of segsPerKey
+// segments.
+func (m *Map) Add(keys ...string) {
+	for _, key := range keys {
+		m.keys[key] = struct{}{}
+		for i := 0; i < m.segsPerKey; i++ {
+			hash := m.hash([]byte(strconv.Itoa(i) + key))
+			// If there's a collision on a "replica" (segment-boundary), we only want
+			// the entry that sorts latest to get inserted (not the last one we saw).
+			//
+			// It doesn't matter how we reconcile collisions (the smallest would work
+			// just as well), we just need it to be insertion-order independent so all
+			// instances converge on the same hashmap.
+			if extKey, ok := m.hashMap[hash]; !ok {
+				// Only add another member for this hash-value if there isn't
+				// one there already.
+				m.keyHashes = append(m.keyHashes, hash)
+			} else if extKey >= key {
+				continue
+			}
+			m.hashMap[hash] = key
+		}
+	}
+	sort.Slice(m.keyHashes, func(i, j int) bool { return m.keyHashes[i] < m.keyHashes[j] })
+}
+
+// GetReplicated gets the closest item in the hash to a deterministic set of
+// keyReplicas variations of the provided key.
+// The returned set of segment-owning keys is dedup'd, and collisions are
+// resolved by traversing backwards in the hash-ring to find an unused
+// owning-key.
+func (m *Map) GetReplicated(key string, keyReplicas int) []string {
+	if m.IsEmpty() {
+		return []string{}
+	}
+	out := make([]string, 0, keyReplicas)
+	segOwners := make(map[string]struct{}, keyReplicas)
+
+	for i := 0; i < keyReplicas && len(out) < len(m.keys); i++ {
+		h := m.idxedKeyReplica(key, i)
+		segIdx, _, owner := m.findSegmentOwner(h)
+		for _, present := segOwners[owner]; present; _, present = segOwners[owner] {
+			// this may overflow, which is fine.
+			segIdx, _, owner = m.nextSegmentOwner(segIdx)
+		}
+		segOwners[owner] = struct{}{}
+		out = append(out, owner)
+	}
+
+	return out
+}

--- a/consistenthash/map_rangefunc.go
+++ b/consistenthash/map_rangefunc.go
@@ -1,0 +1,100 @@
+//go:build go1.23
+
+/*
+Copyright 2013 Google Inc.
+Copyright 2019-2025 Vimeo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consistenthash
+
+import (
+	"iter"
+	"slices"
+	"strconv"
+)
+
+func (m *Map) ownerKeyHashes(ownerKey string) iter.Seq[uint32] {
+	return func(yield func(uint32) bool) {
+		for i := range m.segsPerKey {
+			// note: this is not a particularly good mechanism for generating these keys, but it's what's
+			// been used by groupcache and galaxycache for years, and we can't change it without breaking
+			// existing deployments.
+			if !yield(m.hash([]byte(strconv.Itoa(i) + ownerKey))) {
+				return
+			}
+		}
+	}
+}
+
+// Add adds some keys to the hashring, establishing ownership of segsPerKey
+// segments.
+func (m *Map) Add(ownerKeys ...string) {
+	for _, key := range ownerKeys {
+		m.keys[key] = struct{}{}
+		for hash := range m.ownerKeyHashes(key) {
+			// If there's a collision on a "replica" (segment-boundary), we only want
+			// the entry that sorts latest to get inserted (not the last one we saw).
+			//
+			// It doesn't matter how we reconcile collisions (the smallest would work
+			// just as well), we just need it to be insertion-order independent so all
+			// instances converge on the same hashmap.
+			if extKey, ok := m.hashMap[hash]; !ok {
+				// Only add another member for this hash-value if there isn't
+				// one there already.
+				m.keyHashes = append(m.keyHashes, hash)
+			} else if extKey >= key {
+				continue
+			}
+			m.hashMap[hash] = key
+		}
+	}
+	slices.Sort(m.keyHashes)
+}
+
+// returns the owner of the hash, and the upper-bound for that owner's segment
+func (m *Map) getReplicated(key string, keyReplicas int) iter.Seq2[string, uint32] {
+	segOwners := make(map[string]struct{}, keyReplicas)
+	return func(yield func(string, uint32) bool) {
+		for i := range min(keyReplicas, len(m.keys)) {
+			h := m.idxedKeyReplica(key, i)
+			segIdx, segBound, owner := m.findSegmentOwner(h)
+			for _, present := segOwners[owner]; present; _, present = segOwners[owner] {
+				// this may overflow, which is fine.
+				segIdx, segBound, owner = m.nextSegmentOwner(segIdx)
+			}
+			segOwners[owner] = struct{}{}
+			if !yield(owner, segBound) {
+				return
+			}
+		}
+	}
+}
+
+// GetReplicated gets the closest item in the hash to a deterministic set of
+// keyReplicas variations of the provided key.
+// The returned set of segment-owning keys is dedup'd, and collisions are
+// resolved by traversing backwards in the hash-ring to find an unused
+// owning-key.
+func (m *Map) GetReplicated(key string, keyReplicas int) []string {
+	if m.IsEmpty() {
+		return []string{}
+	}
+	out := make([]string, 0, keyReplicas)
+
+	for owner := range m.getReplicated(key, keyReplicas) {
+		out = append(out, owner)
+	}
+	return out
+}


### PR DESCRIPTION
Use build-tagged files to provide range-function (go 1.23+ iterators)
internally so we can pull out loops over all the hashes for a key or
ownerKey. (leave a build-tagged file with the older version in-place for
backwards compatibility)
