### PR TITLE
chtest: key pregistration & non-test build tag

### DIFF
--- a/consistenthash/chtest/fake_hash.go
+++ b/consistenthash/chtest/fake_hash.go
@@ -1,7 +1,7 @@
 //go:build go1.23
 
 // Package chtest provides some helper hash-functions for use with the parent
-// consistenhash package (and galaxycache) to provide particular owners for
+// consistenthash package (and galaxycache) to provide particular owners for
 // specific keys.
 //
 // This package cannot be imported outside of tests.

--- a/consistenthash/chtest/fake_hash.go
+++ b/consistenthash/chtest/fake_hash.go
@@ -4,7 +4,11 @@
 // consistenhash package (and galaxycache) to provide particular owners for
 // specific keys.
 //
-// This package cannot be imported outside of tests. (If [testing.Testing] returns false, it will panic in init())
+// This package cannot be imported outside of tests.
+// If [testing.Testing] returns false, it will panic in init() unless compiled
+// with the `testing_binary_chtest_can_panic_at_any_time` build tag (intended
+// to be used for tests that require running a separate binary
+// (e.g. integration/interop tests)).
 package chtest
 
 import (
@@ -13,17 +17,10 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/vimeo/galaxycache/cachekey"
 	"github.com/vimeo/galaxycache/consistenthash"
 )
-
-func init() {
-	if !testing.Testing() {
-		panic("attempt to use galaxycache's consistenthash/chtest package outside a test")
-	}
-}
 
 const singleOwnerPrefix = "Single Key Prefix\000\000"
 const fallthroughOwnerKeyPrefix = "Fallthrough Key Prefix\000\000"

--- a/consistenthash/chtest/test_check.go
+++ b/consistenthash/chtest/test_check.go
@@ -1,0 +1,11 @@
+//go:build go1.23 && !testing_binary_chtest_can_panic_at_any_time
+
+package chtest
+
+import "testing"
+
+func init() {
+	if !testing.Testing() {
+		panic("attempt to use galaxycache's consistenthash/chtest package outside a test")
+	}
+}


### PR DESCRIPTION
- **chtest: add key pre-registration (with replicas)**
  

- **chtest: move in-test check to its own file**
  The backwards-compatiblity tests we'll be adding will be much easier to
  work with if they can use the chtest package, but since they'll be
  separate modules, it'll be useful to have the chtest package.
  
  Since those will be run with `go run` via os/exec, we won't have any
  problem setting `-tags`, so we can set a nice, long. scary-sounding
  build-tag to gain access to chtest outside a test.
  