### PR TITLE
peek: add stub handling in Galaxy & gRPC+HTTP handling

### DIFF
--- a/galaxycachepb/galaxycache.pb.go
+++ b/galaxycachepb/galaxycache.pb.go
@@ -185,6 +185,140 @@ func (b0 GetResponse_builder) Build() *GetResponse {
 	return m0
 }
 
+type PeekRequest struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Galaxy string                 `protobuf:"bytes,1,opt,name=galaxy"`
+	xxx_hidden_Key    []byte                 `protobuf:"bytes,2,opt,name=key"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PeekRequest) Reset() {
+	*x = PeekRequest{}
+	mi := &file_galaxycachepb_galaxycache_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PeekRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PeekRequest) ProtoMessage() {}
+
+func (x *PeekRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_galaxycachepb_galaxycache_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PeekRequest) GetGalaxy() string {
+	if x != nil {
+		return x.xxx_hidden_Galaxy
+	}
+	return ""
+}
+
+func (x *PeekRequest) GetKey() []byte {
+	if x != nil {
+		return x.xxx_hidden_Key
+	}
+	return nil
+}
+
+func (x *PeekRequest) SetGalaxy(v string) {
+	x.xxx_hidden_Galaxy = v
+}
+
+func (x *PeekRequest) SetKey(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Key = v
+}
+
+type PeekRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Galaxy string
+	Key    []byte
+}
+
+func (b0 PeekRequest_builder) Build() *PeekRequest {
+	m0 := &PeekRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Galaxy = b.Galaxy
+	x.xxx_hidden_Key = b.Key
+	return m0
+}
+
+type PeekResponse struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Value []byte                 `protobuf:"bytes,1,opt,name=value"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *PeekResponse) Reset() {
+	*x = PeekResponse{}
+	mi := &file_galaxycachepb_galaxycache_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PeekResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PeekResponse) ProtoMessage() {}
+
+func (x *PeekResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_galaxycachepb_galaxycache_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PeekResponse) GetValue() []byte {
+	if x != nil {
+		return x.xxx_hidden_Value
+	}
+	return nil
+}
+
+func (x *PeekResponse) SetValue(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Value = v
+}
+
+type PeekResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Value []byte
+}
+
+func (b0 PeekResponse_builder) Build() *PeekResponse {
+	m0 := &PeekResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Value = b.Value
+	return m0
+}
+
 var File_galaxycachepb_galaxycache_proto protoreflect.FileDescriptor
 
 const file_galaxycachepb_galaxycache_proto_rawDesc = "" +
@@ -197,20 +331,30 @@ const file_galaxycachepb_galaxycache_proto_rawDesc = "" +
 	"\vGetResponse\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\fR\x05value\x12\x1d\n" +
 	"\n" +
-	"minute_qps\x18\x02 \x01(\x01R\tminuteQps2U\n" +
+	"minute_qps\x18\x02 \x01(\x01R\tminuteQps\"7\n" +
+	"\vPeekRequest\x12\x16\n" +
+	"\x06galaxy\x18\x01 \x01(\tR\x06galaxy\x12\x10\n" +
+	"\x03key\x18\x02 \x01(\fR\x03key\"$\n" +
+	"\fPeekResponse\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\fR\x05value2\x9c\x01\n" +
 	"\vGalaxyCache\x12F\n" +
-	"\vGetFromPeer\x12\x19.galaxycachepb.GetRequest\x1a\x1a.galaxycachepb.GetResponse\"\x00B6Z*github.com/vimeo/galaxycache/galaxycachepb\x92\x03\a\xd2>\x02\x10\x03\b\x02b\beditionsp\xe8\a"
+	"\vGetFromPeer\x12\x19.galaxycachepb.GetRequest\x1a\x1a.galaxycachepb.GetResponse\"\x00\x12E\n" +
+	"\bPeekPeer\x12\x1a.galaxycachepb.PeekRequest\x1a\x1b.galaxycachepb.PeekResponse\"\x00B6Z*github.com/vimeo/galaxycache/galaxycachepb\x92\x03\a\xd2>\x02\x10\x03\b\x02b\beditionsp\xe8\a"
 
-var file_galaxycachepb_galaxycache_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_galaxycachepb_galaxycache_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_galaxycachepb_galaxycache_proto_goTypes = []any{
-	(*GetRequest)(nil),  // 0: galaxycachepb.GetRequest
-	(*GetResponse)(nil), // 1: galaxycachepb.GetResponse
+	(*GetRequest)(nil),   // 0: galaxycachepb.GetRequest
+	(*GetResponse)(nil),  // 1: galaxycachepb.GetResponse
+	(*PeekRequest)(nil),  // 2: galaxycachepb.PeekRequest
+	(*PeekResponse)(nil), // 3: galaxycachepb.PeekResponse
 }
 var file_galaxycachepb_galaxycache_proto_depIdxs = []int32{
 	0, // 0: galaxycachepb.GalaxyCache.GetFromPeer:input_type -> galaxycachepb.GetRequest
-	1, // 1: galaxycachepb.GalaxyCache.GetFromPeer:output_type -> galaxycachepb.GetResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
+	2, // 1: galaxycachepb.GalaxyCache.PeekPeer:input_type -> galaxycachepb.PeekRequest
+	1, // 2: galaxycachepb.GalaxyCache.GetFromPeer:output_type -> galaxycachepb.GetResponse
+	3, // 3: galaxycachepb.GalaxyCache.PeekPeer:output_type -> galaxycachepb.PeekResponse
+	2, // [2:4] is the sub-list for method output_type
+	0, // [0:2] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -227,7 +371,7 @@ func file_galaxycachepb_galaxycache_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_galaxycachepb_galaxycache_proto_rawDesc), len(file_galaxycachepb_galaxycache_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/galaxycachepb/galaxycache.proto
+++ b/galaxycachepb/galaxycache.proto
@@ -35,6 +35,16 @@ message GetResponse {
   double minute_qps = 2;
 }
 
+message PeekRequest {
+  string galaxy = 1;
+  bytes key = 2;  // not required/guaranteed to be UTF-8
+}
+
+message PeekResponse {
+  bytes value = 1;
+}
+
 service GalaxyCache {
   rpc GetFromPeer(GetRequest) returns (GetResponse) {}
+  rpc PeekPeer(PeekRequest) returns (PeekResponse) {}
 }

--- a/galaxycachepb/galaxycache_grpc.pb.go
+++ b/galaxycachepb/galaxycache_grpc.pb.go
@@ -36,6 +36,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	GalaxyCache_GetFromPeer_FullMethodName = "/galaxycachepb.GalaxyCache/GetFromPeer"
+	GalaxyCache_PeekPeer_FullMethodName    = "/galaxycachepb.GalaxyCache/PeekPeer"
 )
 
 // GalaxyCacheClient is the client API for GalaxyCache service.
@@ -43,6 +44,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type GalaxyCacheClient interface {
 	GetFromPeer(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetResponse, error)
+	PeekPeer(ctx context.Context, in *PeekRequest, opts ...grpc.CallOption) (*PeekResponse, error)
 }
 
 type galaxyCacheClient struct {
@@ -63,11 +65,22 @@ func (c *galaxyCacheClient) GetFromPeer(ctx context.Context, in *GetRequest, opt
 	return out, nil
 }
 
+func (c *galaxyCacheClient) PeekPeer(ctx context.Context, in *PeekRequest, opts ...grpc.CallOption) (*PeekResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PeekResponse)
+	err := c.cc.Invoke(ctx, GalaxyCache_PeekPeer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // GalaxyCacheServer is the server API for GalaxyCache service.
 // All implementations must embed UnimplementedGalaxyCacheServer
 // for forward compatibility.
 type GalaxyCacheServer interface {
 	GetFromPeer(context.Context, *GetRequest) (*GetResponse, error)
+	PeekPeer(context.Context, *PeekRequest) (*PeekResponse, error)
 	mustEmbedUnimplementedGalaxyCacheServer()
 }
 
@@ -80,6 +93,9 @@ type UnimplementedGalaxyCacheServer struct{}
 
 func (UnimplementedGalaxyCacheServer) GetFromPeer(context.Context, *GetRequest) (*GetResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetFromPeer not implemented")
+}
+func (UnimplementedGalaxyCacheServer) PeekPeer(context.Context, *PeekRequest) (*PeekResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PeekPeer not implemented")
 }
 func (UnimplementedGalaxyCacheServer) mustEmbedUnimplementedGalaxyCacheServer() {}
 func (UnimplementedGalaxyCacheServer) testEmbeddedByValue()                     {}
@@ -120,6 +136,24 @@ func _GalaxyCache_GetFromPeer_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _GalaxyCache_PeekPeer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PeekRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GalaxyCacheServer).PeekPeer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GalaxyCache_PeekPeer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GalaxyCacheServer).PeekPeer(ctx, req.(*PeekRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // GalaxyCache_ServiceDesc is the grpc.ServiceDesc for GalaxyCache service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -130,6 +164,10 @@ var GalaxyCache_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetFromPeer",
 			Handler:    _GalaxyCache_GetFromPeer_Handler,
+		},
+		{
+			MethodName: "PeekPeer",
+			Handler:    _GalaxyCache_PeekPeer_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/grpc/grpc_test.go
+++ b/grpc/grpc_test.go
@@ -28,6 +28,7 @@ import (
 	gc "github.com/vimeo/galaxycache"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestGRPCPeerServer(t *testing.T) {
@@ -41,7 +42,7 @@ func TestGRPCPeerServer(t *testing.T) {
 	var peerAddresses []string
 	var peerListeners []net.Listener
 
-	for i := 0; i < nRoutines; i++ {
+	for range nRoutines {
 		newListener, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatal(err)
@@ -50,7 +51,7 @@ func TestGRPCPeerServer(t *testing.T) {
 		peerListeners = append(peerListeners, newListener)
 	}
 
-	universe := gc.NewUniverse(NewGRPCFetchProtocol(grpc.WithInsecure()), "shouldBeIgnored")
+	universe := gc.NewUniverse(NewGRPCFetchProtocol(grpc.WithTransportCredentials(insecure.NewCredentials())), "shouldBeIgnored")
 	defer func() {
 		shutdownErr := universe.Shutdown()
 		if shutdownErr != nil {
@@ -89,7 +90,7 @@ func TestGRPCPeerServer(t *testing.T) {
 }
 
 func runTestPeerGRPCServer(ctx context.Context, t testing.TB, addresses []string, listener net.Listener, wg *sync.WaitGroup) {
-	universe := gc.NewUniverse(NewGRPCFetchProtocol(grpc.WithInsecure()), listener.Addr().String())
+	universe := gc.NewUniverse(NewGRPCFetchProtocol(grpc.WithTransportCredentials(insecure.NewCredentials())), listener.Addr().String())
 	grpcServer := grpc.NewServer()
 	RegisterGRPCServer(universe, grpcServer)
 	err := universe.Set(addresses...)

--- a/grpc/grpcclient.go
+++ b/grpc/grpcclient.go
@@ -69,6 +69,20 @@ func (gp *GRPCFetchProtocol) NewFetcher(address string) (gc.RemoteFetcher, error
 	return &grpcFetcher{address: address, conn: conn, client: client}, nil
 }
 
+func (g *grpcFetcher) Peek(ctx context.Context, galaxy, key string) ([]byte, error) {
+	span := trace.FromContext(ctx)
+	span.Annotatef(nil, "peeking from %s; connection state %s", g.address, g.conn.GetState())
+	resp, err := g.client.PeekPeer(ctx, pb.PeekRequest_builder{
+		Galaxy: galaxy,
+		Key:    []byte(key),
+	}.Build())
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "Failed to fetch from peer over RPC [%q, %q]: %s", galaxy, g.address, err)
+	}
+
+	return resp.GetValue(), nil
+}
+
 // Fetch here implements the RemoteFetcher interface for
 // sending Gets to peers over an RPC connection
 func (g *grpcFetcher) Fetch(ctx context.Context, galaxy string, key string) ([]byte, error) {

--- a/http/http.go
+++ b/http/http.go
@@ -18,8 +18,9 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -31,6 +32,7 @@ import (
 )
 
 const defaultBasePath = "/_galaxycache/"
+const defaultPeekBasePath = "/_galaxycache_peek/"
 
 // HTTPFetchProtocol specifies HTTP specific options for HTTP-based
 // peer communication
@@ -38,17 +40,20 @@ type HTTPFetchProtocol struct {
 	// Transport optionally specifies an http.RoundTripper for the client
 	// to use when it makes a request.
 	// If nil, the client uses http.DefaultTransport.
-	transport http.RoundTripper
-	basePath  string
+	transport    http.RoundTripper
+	basePath     string
+	peekBasePath string
 }
 
-// HTTPOptions can specify the transport, base path, and stats.Recorder for
-// serving and fetching. *ONLY SPECIFY IF NOT USING THE DEFAULT "/_galaxycache/"
-// BASE PATH*.
+// HTTPOptions can specify the transport, base path, peek base path, and
+// stats.Recorder for serving and fetching.
+// *ONLY SPECIFY the base path IF NOT USING THE DEFAULT "/_galaxycache/" BASE PATH*.
+// *ONLY SPECIFY the peek base path IF NOT USING THE DEFAULT "/_galaxycache_peek/" BASE PATH*.
 type HTTPOptions struct {
-	Transport http.RoundTripper
-	BasePath  string
-	Recorder  stats.Recorder
+	Transport    http.RoundTripper
+	BasePath     string
+	PeekBasePath string
+	Recorder     stats.Recorder
 }
 
 // NewHTTPFetchProtocol creates an HTTP fetch protocol to be passed
@@ -58,7 +63,8 @@ type HTTPOptions struct {
 // HTTPHandler on the same Universe*.
 func NewHTTPFetchProtocol(opts *HTTPOptions) *HTTPFetchProtocol {
 	newProto := &HTTPFetchProtocol{
-		basePath: defaultBasePath,
+		basePath:     defaultBasePath,
+		peekBasePath: defaultPeekBasePath,
 	}
 
 	if opts == nil {
@@ -70,6 +76,9 @@ func NewHTTPFetchProtocol(opts *HTTPOptions) *HTTPFetchProtocol {
 	}
 	if opts.BasePath != "" {
 		newProto.basePath = opts.BasePath
+	}
+	if opts.PeekBasePath != "" {
+		newProto.peekBasePath = opts.PeekBasePath
 	}
 
 	return newProto
@@ -90,9 +99,10 @@ func (hp *HTTPFetchProtocol) NewFetcher(url string) (gc.RemoteFetcher, error) {
 // request; it contains a pointer to its parent Universe in order to access
 // its galaxies
 type HTTPHandler struct {
-	universe *gc.Universe
-	basePath string
-	recorder stats.Recorder
+	universe     *gc.Universe
+	basePath     string
+	peekBasePath string
+	recorder     stats.Recorder
 }
 
 // RegisterHTTPHandler sets up an HTTPHandler with a user specified path
@@ -106,28 +116,45 @@ type HTTPHandler struct {
 // if specifying a serveMux.
 func RegisterHTTPHandler(universe *gc.Universe, opts *HTTPOptions, serveMux *http.ServeMux) {
 	basePath := defaultBasePath
+	peekBasePath := defaultPeekBasePath
 	var recorder stats.Recorder
 	if opts != nil {
-		basePath = opts.BasePath
+		if opts.BasePath != "" {
+			basePath = opts.BasePath
+		}
+		if opts.PeekBasePath != "" {
+			peekBasePath = opts.PeekBasePath
+		}
 		recorder = opts.Recorder
 	}
 	newHTTPHandler := &HTTPHandler{
-		basePath: basePath,
-		universe: universe,
-		recorder: recorder,
+		basePath:     basePath,
+		peekBasePath: peekBasePath,
+		universe:     universe,
+		recorder:     recorder,
 	}
 	if serveMux == nil {
 		http.Handle(basePath, &ochttp.Handler{
 			Handler: ochttp.WithRouteTag(newHTTPHandler, basePath),
 		})
+		http.Handle(peekBasePath, &ochttp.Handler{
+			Handler: ochttp.WithRouteTag(newHTTPHandler, peekBasePath),
+		})
 	} else {
 		serveMux.Handle(basePath, ochttp.WithRouteTag(newHTTPHandler, basePath))
+		serveMux.Handle(peekBasePath, ochttp.WithRouteTag(newHTTPHandler, peekBasePath))
 	}
 }
 
 func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	peek := false
 	// Parse request.
-	if !strings.HasPrefix(r.URL.Path, h.basePath) {
+	switch {
+	case strings.HasPrefix(r.URL.Path, h.basePath):
+		peek = false
+	case strings.HasPrefix(r.URL.Path, h.peekBasePath):
+		peek = true
+	default:
 		panic("HTTPHandler serving unexpected path: " + r.URL.Path)
 	}
 	strippedPath := r.URL.Path[len(h.basePath):]
@@ -161,9 +188,11 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Fetch the value for this galaxy/key.
 	galaxy := h.universe.GetGalaxy(galaxyName)
 	if galaxy == nil {
+		w.Header().Set(galaxyPresentHeader, galaxyStatusNotFound)
 		http.Error(w, "no such galaxy: "+galaxyName, http.StatusNotFound)
 		return
 	}
+	w.Header().Set(galaxyPresentHeader, galaxyStatusFound)
 
 	ctx := r.Context()
 
@@ -174,9 +203,19 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		stats.WithMeasurements(gc.MServerRequests.M(1)),
 		stats.WithRecorder(h.recorder),
 	)
+
+	fetchMode := gc.FetchModeNoPeerBackend
+	if peek {
+		fetchMode = gc.FetchModePeek
+	}
+
 	var value gc.ByteCodec
-	err := galaxy.Get(ctx, key, &value)
+	_, err := galaxy.GetWithOptions(ctx, gc.GetOptions{FetchMode: fetchMode}, key, &value)
 	if err != nil {
+		if nfErr := gc.NotFoundErr(nil); errors.As(err, &nfErr) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -184,20 +223,40 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write(value)
 }
 
+const galaxyPresentHeader = "X-Galaxycache-Galaxy-Status"
+
+const galaxyStatusFound = "Found"
+const galaxyStatusNotFound = "Not Found"
+
 type httpFetcher struct {
-	transport http.RoundTripper
-	baseURL   string
+	transport   http.RoundTripper
+	baseURL     string
+	basePeekURL string
 }
 
 // Fetch here implements the RemoteFetcher interface for sending a GET request over HTTP to a peer
 func (h *httpFetcher) Fetch(ctx context.Context, galaxy string, key string) ([]byte, error) {
+	return h.fetch(ctx, false, galaxy, key)
+}
+
+// Peek here implements the RemoteFetcher interface for sending a GET request over HTTP to a peer
+func (h *httpFetcher) Peek(ctx context.Context, galaxy string, key string) ([]byte, error) {
+	return h.fetch(ctx, true, galaxy, key)
+}
+
+// fetch backs both Fetch and Peek
+func (h *httpFetcher) fetch(ctx context.Context, peek bool, galaxy string, key string) ([]byte, error) {
+	baseURL := h.baseURL
+	if peek {
+		baseURL = h.basePeekURL
+	}
 	u := fmt.Sprintf(
 		"%v%v/%v",
-		h.baseURL,
+		baseURL,
 		url.PathEscape(galaxy),
 		url.PathEscape(key),
 	)
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -206,14 +265,29 @@ func (h *httpFetcher) Fetch(ctx context.Context, galaxy string, key string) ([]b
 		return nil, err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
+	switch res.StatusCode {
+	case http.StatusNotFound:
+		switch galaxyPresent := res.Header.Get(galaxyPresentHeader); galaxyPresent {
+		case galaxyStatusNotFound:
+			return nil, errors.New("galaxy not found")
+		case galaxyStatusFound:
+			return nil, fmt.Errorf("key not found: %w", gc.TrivialNotFoundErr{})
+		default:
+			// anything else, including a missing header (either an
+			// older version of galaxycache, or the HTTP handler's
+			// not registered for that path)
+			return nil, fmt.Errorf("server returned HTTP response status code: %v; %q header: %q",
+				res.Status, galaxyPresentHeader, galaxyPresent)
+		}
+	case http.StatusOK:
+		data, err := io.ReadAll(res.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading response body: %v", err)
+		}
+		return data, nil
+	default:
 		return nil, fmt.Errorf("server returned HTTP response status code: %v", res.Status)
 	}
-	data, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %v", err)
-	}
-	return data, nil
 }
 
 // Close here implements the RemoteFetcher interface for closing (does nothing for HTTP)

--- a/peers.go
+++ b/peers.go
@@ -47,7 +47,7 @@ type RemoteFetcher interface {
 	Close() error
 }
 
-// wrapper around consistendhash.Map to track hashes for Peek calls.
+// wrapper around consistenthash.Map to track hashes for Peek calls.
 type peekMap struct {
 	// map that never includes "self"
 	// TODO: include dying peers for some time

--- a/peers.go
+++ b/peers.go
@@ -28,10 +28,12 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/vimeo/galaxycache/consistenthash"
+	clocks "github.com/vimeo/go-clocks"
 )
 
 const defaultReplicas = 50
@@ -45,6 +47,16 @@ type RemoteFetcher interface {
 	Close() error
 }
 
+// wrapper around consistendhash.Map to track hashes for Peek calls.
+type peekMap struct {
+	// map that never includes "self"
+	// TODO: include dying peers for some time
+	peekMap  *consistenthash.Map
+	initTime time.Time
+
+	// TODO: add support for peer-death
+}
+
 // PeerPicker is in charge of dealing with peers: it contains the hashing
 // options (hash function and number of replicas), consistent hash map of
 // peers, and a map of RemoteFetchers to those peers
@@ -53,10 +65,12 @@ type PeerPicker struct {
 	selfID           string
 	includeSelf      bool
 	peerIDs          *consistenthash.Map
+	peekMap          peekMap
 	fetchers         map[string]RemoteFetcher // keyed by ID
 	mapGen           peerSetGeneration
 	mu               sync.RWMutex
 	opts             HashOptions
+	clock            clocks.Clock
 }
 
 // HashOptions specifies the the hash function and the number of replicas
@@ -72,12 +86,13 @@ type HashOptions struct {
 }
 
 // Creates a peer picker; called when creating a new Universe
-func newPeerPicker(proto FetchProtocol, selfID string, options *HashOptions) *PeerPicker {
+func newPeerPicker(proto FetchProtocol, clk clocks.Clock, selfID string, options *HashOptions) *PeerPicker {
 	pp := &PeerPicker{
 		fetchingProtocol: proto,
 		selfID:           selfID,
 		fetchers:         make(map[string]RemoteFetcher),
 		includeSelf:      true,
+		clock:            clk,
 	}
 	if options != nil {
 		pp.opts = *options
@@ -86,7 +101,26 @@ func newPeerPicker(proto FetchProtocol, selfID string, options *HashOptions) *Pe
 		pp.opts.Replicas = defaultReplicas
 	}
 	pp.peerIDs = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
+	pp.peekMap.initTime = clk.Now()
+	pp.peekMap.peekMap = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
 	return pp
+}
+
+// When passed a key, the consistent hash is used to determine which
+// peer is responsible getting/caching it
+func (pp *PeerPicker) pickPeekPeer(warmTime time.Duration, key string) (RemoteFetcher, bool) {
+	if pp.clock.Now().Sub(pp.peekMap.initTime) >= warmTime {
+		// if it's been more than warmTime since init, we don't want to make peek requests. (for now)
+		// TODO: handle peer scale-downs.
+		return nil, false
+	}
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	if peerName := pp.peekMap.peekMap.Get(key); peerName != "" {
+		peer, ok := pp.fetchers[peerName]
+		return peer, ok
+	}
+	return nil, false
 }
 
 // When passed a key, the consistent hash is used to determine which
@@ -118,6 +152,8 @@ type Peer struct {
 	// URI should be a valid base URL,
 	// for example "example.net:8000" or "10.32.54.231:8123".
 	URI string
+
+	// TODO: add a start-time to hint peeking
 }
 
 type peerSetGeneration uint64
@@ -298,6 +334,7 @@ func (pp *PeerPicker) insertPeer(peer Peer, fetcher RemoteFetcher) bool {
 	pp.fetchers[peer.ID] = fetcher
 	// No need to initialize a new peer hashring, we're only adding peers.
 	pp.peerIDs.Add(peer.ID)
+	pp.peekMap.peekMap.Add(peer.ID)
 	return true
 }
 
@@ -359,6 +396,13 @@ func (pp *PeerPicker) regenerateHashringLocked() {
 	pp.peerIDs = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
 	pp.peerIDs.Add(newPeerIDs...)
 	pp.mapGen++
+
+	pp.peekMap.peekMap = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
+	// omit the self-entry, if present when regenerating the peekMap
+	// TODO: move this part to a method on peekMap and track pending removals.
+	//       (we don't want to remove peers from the peek map until we
+	//       start getting errors sending peek requests to them -- that aren't not-founds)
+	pp.peekMap.peekMap.Add(newPeerIDs[selfAdj:]...)
 }
 
 func (pp *PeerPicker) includeSelfVal() bool {

--- a/peers_test.go
+++ b/peers_test.go
@@ -3,16 +3,29 @@ package galaxycache
 import (
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/vimeo/galaxycache/consistenthash/chtest"
+	"github.com/vimeo/go-clocks/fake"
 )
 
 // TestPeers tests to ensure that an instance with given hash
 // function results in the expected number of gets both locally and into each other peer
 func TestPeersIncremental(t *testing.T) {
+	const (
+		peer3 = "fizzlebat3"
+		peer4 = "fizzlebat4"
+		peer5 = "fizzlebat5"
+	)
 
-	hashOpts := &HashOptions{
-		Replicas: 2,
-		HashFn:   nil,
-	}
+	const selfID = "selfImpossibleFetcher"
+
+	ma := chtest.NewMapArgs(chtest.Args{
+		Owners: []string{selfID, peer3, peer4, peer5},
+		RegisterKeys: map[string][]string{
+			"a": nil,
+		},
+	})
 
 	type addRemoveStep struct {
 		add           []Peer
@@ -23,97 +36,146 @@ func TestPeersIncremental(t *testing.T) {
 		expectFailRm  bool
 		includeSelf   bool
 		setIncSelf    bool
+
+		// map from a key to the URI of the peer that should receive a peek call
+		// a nil value indicates no-one (e.g. we're more than warmTime past init)
+		expPeeks map[string]*string
 	}
 
-	const selfID = "selfImpossibleFetcher"
+	strPtr := func(s string) *string {
+		return &s
+	}
+
 	testCases := []struct {
 		name        string
 		initFunc    func(testProtocol *TestProtocol)
 		cacheSize   int64
 		includeSelf bool
+		advanceIncr time.Duration
+		warmTime    time.Duration
 		steps       []addRemoveStep
 	}{
 		{
-			name:      "base_add_remove_serial",
-			initFunc:  func(*TestProtocol) {},
-			cacheSize: 1 << 20,
+			name:        "base_add_remove_serial",
+			initFunc:    func(*TestProtocol) {},
+			cacheSize:   1 << 20,
+			warmTime:    time.Minute * 30,
+			advanceIncr: time.Minute * 10,
 			steps: []addRemoveStep{
 				{
-					add:           []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}},
+					add:           []Peer{{ID: peer3, URI: "fizzleboot3"}, {ID: peer4, URI: "fizzleboot4"}},
 					remove:        []string{},
-					expectedPeers: []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}},
+					expectedPeers: []Peer{{ID: peer3, URI: "fizzleboot3"}, {ID: peer4, URI: "fizzleboot4"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true, // include self, but don't alter the default
 					setIncSelf:    false,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer3): strPtr("fizzleboot3"),
+						chtest.FallthroughKey(selfID, peer4): strPtr("fizzleboot4"),
+					},
 				},
 				{
 					add:           []Peer{},
-					remove:        []string{"fizzlebat3", "fizzleboat3"}, // remove a name that doesn't exist
-					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					remove:        []string{peer3, "fizzleboat3"}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: peer4, URI: "fizzleboot4"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true, // include self, but don't alter the default
 					setIncSelf:    false,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer3): strPtr("fizzleboot4"),
+						chtest.FallthroughKey(selfID, peer4): strPtr("fizzleboot4"),
+					},
 				},
 				{
 					add:           []Peer{},
 					remove:        []string{}, // remove a name that doesn't exist
-					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					expectedPeers: []Peer{{ID: peer4, URI: "fizzleboot4"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true,
 					setIncSelf:    true,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer3): strPtr("fizzleboot4"),
+						chtest.FallthroughKey(selfID, peer4): strPtr("fizzleboot4"),
+					},
 				},
 				{
 					add:           []Peer{},
 					remove:        []string{}, // remove a name that doesn't exist
-					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					expectedPeers: []Peer{{ID: peer4, URI: "fizzleboot4"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   false,
 					setIncSelf:    true,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer3): nil,
+						chtest.FallthroughKey(selfID, peer4): nil,
+					},
 				},
 				{
 					add:           []Peer{},
 					remove:        []string{}, // remove a name that doesn't exist
-					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					expectedPeers: []Peer{{ID: peer4, URI: "fizzleboot4"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true,
 					setIncSelf:    true,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer3): nil,
+						chtest.FallthroughKey(selfID, peer4): nil,
+					},
 				},
 			},
 		},
 		{
-			name:      "base_add_parallel",
-			initFunc:  func(*TestProtocol) {},
-			cacheSize: 1 << 20,
+			name:        "base_add_parallel",
+			initFunc:    func(*TestProtocol) {},
+			cacheSize:   1 << 20,
+			advanceIncr: time.Minute,
+			warmTime:    time.Hour,
 			steps: []addRemoveStep{
 				{
-					add:           []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}, {ID: "fizzlebat5", URI: "fizzleboot5"}},
+					add:           []Peer{{ID: peer3, URI: "fizzleboot3"}, {ID: peer4, URI: "fizzleboot4"}, {ID: peer5, URI: "fizzleboot5"}},
 					remove:        []string{},
-					expectedPeers: []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}, {ID: "fizzlebat4", URI: "fizzleboot4"}, {ID: "fizzlebat5", URI: "fizzleboot5"}},
+					expectedPeers: []Peer{{ID: peer3, URI: "fizzleboot3"}, {ID: peer4, URI: "fizzleboot4"}, {ID: peer5, URI: "fizzleboot5"}},
 					parallel:      true,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true, // include self, but don't alter the default
 					setIncSelf:    false,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer3): strPtr("fizzleboot3"),
+						chtest.FallthroughKey(selfID, peer4): strPtr("fizzleboot4"),
+						chtest.FallthroughKey(selfID, peer5): strPtr("fizzleboot5"),
+					},
 				},
 				{
 					add:           []Peer{},
-					remove:        []string{"fizzlebat3", "fizzleboat3"}, // remove a name that doesn't exist
-					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}, {ID: "fizzlebat5", URI: "fizzleboot5"}},
+					remove:        []string{peer3, "fizzleboat3"}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: peer4, URI: "fizzleboot4"}, {ID: peer5, URI: "fizzleboot5"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true, // include self, but don't alter the default
 					setIncSelf:    false,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer4): strPtr("fizzleboot4"),
+						chtest.FallthroughKey(selfID, peer5): strPtr("fizzleboot5"),
+					},
 				},
 			},
 		},
@@ -123,9 +185,11 @@ func TestPeersIncremental(t *testing.T) {
 			initFunc: func(proto *TestProtocol) {
 				proto.dialFails = map[string]struct{}{"fizzleboot3": {}}
 			},
+			advanceIncr: time.Minute,
+			warmTime:    time.Hour,
 			steps: []addRemoveStep{
 				{
-					add:           []Peer{{ID: "fizzlebat3", URI: "fizzleboot3"}},
+					add:           []Peer{{ID: peer3, URI: "fizzleboot3"}},
 					remove:        []string{},
 					expectedPeers: []Peer{},
 					parallel:      false,
@@ -133,40 +197,53 @@ func TestPeersIncremental(t *testing.T) {
 					expectFailRm:  false,
 					includeSelf:   true, // include self, but don't alter the default
 					setIncSelf:    false,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer3): nil,
+					},
 				},
 				{
-					add:           []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					add:           []Peer{{ID: peer4, URI: "fizzleboot4"}},
 					remove:        []string{},
-					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					expectedPeers: []Peer{{ID: peer4, URI: "fizzleboot4"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true, // include self, but don't alter the default
 					setIncSelf:    false,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer4): strPtr("fizzleboot4"),
+					},
 				},
 				{
 					add:           []Peer{},
-					remove:        []string{"fizzlebat3", "fizzleboat3"}, // remove a name that doesn't exist
-					expectedPeers: []Peer{{ID: "fizzlebat4", URI: "fizzleboot4"}},
+					remove:        []string{peer3, "fizzleboat3"}, // remove a name that doesn't exist
+					expectedPeers: []Peer{{ID: peer4, URI: "fizzleboot4"}},
 					parallel:      false,
 					expectFailAdd: false,
 					expectFailRm:  false,
 					includeSelf:   true, // include self, but don't alter the default
 					setIncSelf:    false,
+
+					expPeeks: map[string]*string{
+						chtest.FallthroughKey(selfID, peer4): strPtr("fizzleboot4"),
+					},
 				},
 			},
 		},
 	}
 
-	for _, itbl := range testCases {
-		tbl := itbl
-
+	for _, tbl := range testCases {
 		t.Run(tbl.name, func(t *testing.T) {
 			t.Parallel()
 			// instantiate test fetchers with the test protocol
 			testproto := TestProtocol{
 				TestFetchers: make(map[string]*TestFetcher),
 			}
+
+			fc := fake.NewClock(time.Now())
+			t.Logf("test start time %s", fc.Now())
 
 			checkErr := func(expErr bool, addErr error, opName string, stepIdx, opIdx int) {
 				t.Helper()
@@ -181,7 +258,10 @@ func TestPeersIncremental(t *testing.T) {
 				}
 			}
 
-			u := NewUniverseWithOpts(&testproto, selfID, hashOpts)
+			u := NewUniverse(&testproto, selfID, WithHashOpts(&HashOptions{
+				Replicas: ma.NSegsPerKey,
+				HashFn:   ma.HashFunc,
+			}), WithUniversalClock(fc))
 
 			tbl.initFunc(&testproto)
 
@@ -301,6 +381,23 @@ func TestPeersIncremental(t *testing.T) {
 					t.Errorf("unexpected peer(s)' URI(s) in copy of fetcher-map at step %d: %v",
 						si, allFetcherURIs)
 				}
+
+				for k, expURI := range step.expPeeks {
+					rf, ok := u.peerPicker.pickPeekPeer(tbl.warmTime, k)
+					if ok != (expURI != nil) {
+						t.Errorf("unexpected pickPeekPeer status at timestamp %s for key %q; got %t; want %t",
+							fc.Now(), k, ok, expURI != nil)
+					} else if ok {
+						if rf == nil {
+							t.Fatalf("ok is true, but remote fetcher is nil for key %s at time %s", k, fc.Now())
+						}
+						if u := rf.(*TestFetcher).uri; u != *expURI {
+							t.Errorf("unexpected URI for key %q: got %q; want %q", k, u, *expURI)
+						}
+					}
+				}
+
+				fc.Advance(tbl.advanceIncr)
 			}
 		})
 	}


### PR DESCRIPTION
- **PeerPicker: add peek picking**
  Add a new hashring to the PeerPicker that always excludes "self".
  Additionaly, add a method so we can pick the peer that should receive
  a specific Peek call.
  
  Make some adjustments to the tests and plumb a clock in through the
  universe.
  
  Also, bump go.mod to go 1.23 so we can use chtest in the root package's
  tests.
  

- **GetWithOptions: minimal interface update**
  More will come in a later commit, but this provides the minimum required
  so we can update the http and grpc subpackages to implement the Peek
  method without actually having those methods be called.
  

- **http: implement Peek method & NotFoundErr handling**
  Add support for propagating NotFound errors as
  well as adding support for a path that only handles peeks.
  
  Do a bit of minor modernization (e.g. ioutil.ReadAll -> io.ReadAll).
  
  Tests to come later.
  

- **grpc: Peek method**
  Add a `PeekPeer` gRPC method that provides the Peek functionality.
  
  For uniformity, switch to calling the new `GetWithOptions` method. (it
  doesn't do anything different for the moment, because only FetchModePeek
  is implmented, but the next commit will implement Peek in the Galaxy, at
  which point this will prevent distributed deadlocks if anything is
  mismatched in the hashring.
  
  The tests have not been updated yet (beyond fixing some staticcheck nits
  about deprecated grpc calls).
  