### PR TITLE
http: consistently drain the response body

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -265,6 +265,9 @@ func (h *httpFetcher) fetch(ctx context.Context, peek bool, galaxy string, key s
 		return nil, err
 	}
 	defer res.Body.Close()
+	// Unconditionally drain any unread bytes in the body so the connection is actually available for reuse.
+	// If io.Copy gets an error we probably can't reuse the connection anyway.
+	defer io.Copy(io.Discard, res.Body)
 	switch res.StatusCode {
 	case http.StatusNotFound:
 		switch galaxyPresent := res.Header.Get(galaxyPresentHeader); galaxyPresent {


### PR DESCRIPTION
In order to reuse the connection from HTTP/1.1 requests, we need to have
read the whole body. defer an `io.Copy` into `io.Discard` so even on
errors we can reuse the connection.
