### PR TITLE
chtest: fix segments-per-key calculation & add layout explanation

### DIFF
--- a/consistenthash/chtest/fake_hash.go
+++ b/consistenthash/chtest/fake_hash.go
@@ -72,7 +72,7 @@ func (m *MapArgs) NewMap() *consistenthash.Map {
 func NewMapArgs(args Args) MapArgs {
 	owners := args.Owners
 	ownersMap := make(map[string][]hashRange, len(owners))
-	segsPerKey := len(owners) - 1
+	segsPerKey := (len(owners) - 1) * 2 // we need to cover both orderings for each pair
 	nSegs := segsPerKey * len(owners)
 	type indexedString struct {
 		idx int

--- a/consistenthash/chtest/fake_hash_test.go
+++ b/consistenthash/chtest/fake_hash_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestMapArgs(t *testing.T) {
+func TestMapArgs3Peers(t *testing.T) {
 	// owners
 	const (
 		peer1 = "peer1"
@@ -27,7 +27,7 @@ func TestMapArgs(t *testing.T) {
 			"p1p2explicit": {peer1, peer2},
 		},
 	})
-	if expSegs := 2; ma.NSegsPerKey != expSegs {
+	if expSegs := 4; ma.NSegsPerKey != expSegs {
 		t.Errorf("unexpected number of key segments: %d; expected %d", ma.NSegsPerKey, expSegs)
 	}
 	// make the full map function-scope so we can log it in error cases for later scopes
@@ -92,4 +92,101 @@ func TestMapArgs(t *testing.T) {
 		}
 	}
 
+}
+
+func TestMapArgs2Peers(t *testing.T) {
+	// owners
+	const (
+		peer1 = "peer1"
+		peer2 = "peer2"
+	)
+	soP1 := SingleOwnerKey(peer1)
+	soP2 := SingleOwnerKey(peer2)
+	ftP1P2 := FallthroughKey(peer1, peer2)
+	ftP2P1 := FallthroughKey(peer2, peer1)
+
+	ma := NewMapArgs(Args{
+		Owners: []string{peer1, peer2},
+		RegisterKeys: map[string][]string{
+			"allpeers":     nil,
+			"p1explicit":   {peer1},
+			"p2explicit":   {peer2},
+			"p1p2explicit": {peer1, peer2},
+		},
+	})
+	if expSegs := 2; ma.NSegsPerKey != expSegs {
+		t.Errorf("unexpected number of key segments: %d; expected %d", ma.NSegsPerKey, expSegs)
+	}
+	// make the full map function-scope so we can log it in error cases for later scopes
+	fullMap := ma.NewMap()
+	fullMap.Add(peer1, peer2)
+	{
+		if soP1Owner := fullMap.Get(soP1); soP1Owner != peer1 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", soP1, soP1Owner, peer1)
+		}
+		if soP2Owner := fullMap.Get(soP2); soP2Owner != peer2 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", soP2, soP2Owner, peer2)
+		}
+		if soP1Owner := fullMap.Get(ftP1P2); soP1Owner != peer1 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", ftP1P2, soP1Owner, peer1)
+		}
+		if soP2Owner := fullMap.Get(ftP2P1); soP2Owner != peer2 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", ftP2P1, soP2Owner, peer2)
+			t.Logf("full ring: %+v", fullMap)
+			t.Logf("p2p1 hash: %d", ma.HashFunc([]byte(ftP1P2)))
+		}
+		if explAllOwner := fullMap.Get("allpeers"); explAllOwner != peer1 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", "allpeers", explAllOwner, peer1)
+		}
+		// fetch with the same number of replicas as peers
+		if explAllOwner := fullMap.GetReplicated("allpeers", 2); !slices.Equal(explAllOwner, []string{peer1, peer2}) {
+			t.Errorf("unexpected peer owners for key %q; got %v; want %v", "allpeers", explAllOwner, []string{peer1, peer2})
+		}
+		// fetch with more replicas than peers
+		if explAllOwner := fullMap.GetReplicated("allpeers", 8); !slices.Equal(explAllOwner, []string{peer1, peer2}) {
+			t.Errorf("unexpected peer owners for key %q; got %v; want %v", "allpeers", explAllOwner, []string{peer1, peer2})
+		}
+		if explP1Owner := fullMap.Get("p1explicit"); explP1Owner != peer1 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", "p1explicit", explP1Owner, peer1)
+		}
+		if explP2Owner := fullMap.Get("p2explicit"); explP2Owner != peer2 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", "p2explicit", explP2Owner, peer2)
+		}
+		if explP1P2Owner := fullMap.GetReplicated("p1p2explicit", 2); !slices.Equal(explP1P2Owner, []string{peer1, peer2}) {
+			t.Errorf("unexpected peer owners for key %q; got %v; want %v", "p1p2explicit", explP1P2Owner, []string{peer1, peer2})
+		}
+	}
+	{
+		ftP1P2 := FallthroughKey(peer1, peer2)
+		mapSansPeer1 := ma.NewMap()
+		mapSansPeer1.Add(peer2)
+		if soP1Owner := mapSansPeer1.Get(soP1); soP1Owner == peer1 {
+			t.Errorf("unexpected peer owner for key %q; got %q; wanted something other than %q (excluded from ring)", soP1, soP1Owner, peer1)
+		}
+		if soP2Owner := mapSansPeer1.Get(soP2); soP2Owner != peer2 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", soP2, soP2Owner, peer2)
+		}
+		if soP2Owner := mapSansPeer1.Get(ftP1P2); soP2Owner != peer2 {
+			t.Errorf("unexpected fallthrough peer owner for key %q; got %q; want %q", ftP1P2, soP2Owner, peer2)
+			t.Logf("sans 1 ring: %+v", mapSansPeer1)
+			t.Logf("full ring: %+v", fullMap)
+			t.Logf("p2FallThrough hash: %d", ma.HashFunc([]byte(ftP1P2)))
+		}
+	}
+	{
+		mapSansPeer1 := ma.NewMap()
+		mapSansPeer1.Add(peer1)
+		if soP2Owner := mapSansPeer1.Get(soP2); soP2Owner == peer2 {
+			t.Errorf("unexpected peer owner for key %q; got %q; wanted something other than %q (excluded from ring)", soP2, soP2Owner, peer2)
+		}
+		if soP2Owner := mapSansPeer1.Get(soP2); soP2Owner != peer1 {
+			t.Errorf("unexpected peer owner for key %q; got %q; want %q", soP2, soP2Owner, peer1)
+		}
+		if soP2Owner := mapSansPeer1.Get(ftP2P1); soP2Owner != peer1 {
+			t.Errorf("unexpected fallthrough peer owner for key %q; got %q; want %q", ftP2P1, soP2Owner, peer1)
+			t.Logf("sans 1 ring: %+v", mapSansPeer1)
+			t.Logf("full ring: %+v", fullMap)
+			t.Logf("p2FallThrough hash: %d", ma.HashFunc([]byte(ftP2P1)))
+		}
+	}
 }


### PR DESCRIPTION
- **chtest: fix segments_per_key calculation**
  When writing the initial version of this package, I did a back of the
  envelope calculation, and forgot to draw myself a full diagram for the
  n=2 and n=3 cases, meaning that I didn't actually _count_ how many
  entries I needed with the layout I had. Writing it down and counting
  showed that I was off by a factor of 2. (which also jives with the sizes
  of the internal maps/slices this package creates (which are
  unfortunately only visible in a debugger because they're only propagated
  by the hash-function closure's capture)
  

- **chtest: add block comment explaining hash layout**
  Since I needed to write this down on paper to understand the map myself,
  I might as well add add a doc-comment that explains it in detail for
  everyone. (including future me)
  