### PR TITLE
Fix peek metrics and reword doc-comment

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -522,7 +522,7 @@ func (g *Galaxy) recordRequest(ctx context.Context, h hitLevel, localAuthoritati
 		g.recordStats(ctx, []tag.Mutator{tag.Upsert(CacheLevelKey, h.String())}, MCacheHits.M(1))
 	case hitPeek:
 		g.Stats.PeerPeekHits.Add(1)
-		g.recordStats(ctx, []tag.Mutator{tag.Upsert(CacheLevelKey, h.String())}, MCacheHits.M(1), MPeeks.M(1))
+		g.recordStats(ctx, nil, MPeeks.M(1))
 	case hitPeer:
 		g.Stats.PeerLoads.Add(1)
 		g.recordStats(ctx, nil, MPeerLoads.M(1))

--- a/observability.go
+++ b/observability.go
@@ -78,6 +78,7 @@ var (
 var AllViews = []*view.View{
 	{Measure: MGets, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MLoadErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MCacheHits, TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Aggregation: view.Count()},
 	{Measure: MPeerLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MPeerLoadErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
@@ -87,6 +88,7 @@ var AllViews = []*view.View{
 	{Measure: MBackendLoadErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 
 	{Measure: MCoalescedPeeks, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
+	{Measure: MCoalescedPeekHits, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MCoalescedLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MCoalescedCacheHits, TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Aggregation: view.Count()},
 	{Measure: MCoalescedPeerLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},

--- a/observability.go
+++ b/observability.go
@@ -42,7 +42,6 @@ var (
 	MBackendLoads      = stats.Int64("galaxycache/backend_loads", "The number of successful loads from the backend getter", stats.UnitDimensionless)
 	MBackendLoadErrors = stats.Int64("galaxycache/local_load_errors", "The number of failed backend loads", stats.UnitDimensionless)
 	MPeeks             = stats.Int64("galaxycache/peeks", "The number of remote cache hits via Peek requests", stats.UnitDimensionless)
-	MPeekErrors        = stats.Int64("galaxycache/peek_errors", "The number of remote errors via Peek requests", stats.UnitDimensionless)
 
 	MCoalescedLoads        = stats.Int64("galaxycache/coalesced_loads", "The number of loads coalesced by singleflight", stats.UnitDimensionless)
 	MCoalescedCacheHits    = stats.Int64("galaxycache/coalesced_cache_hits", "The number of coalesced times that the cache was hit", stats.UnitDimensionless)
@@ -50,6 +49,7 @@ var (
 	MCoalescedPeeks        = stats.Int64("galaxycache/coalesced_peeks", "The number of coalesced remote loads via Peek requests", stats.UnitDimensionless)
 	MCoalescedPeekHits     = stats.Int64("galaxycache/coalesced_peek_hits", "The number of coalesced remote cache hits via Peek requests", stats.UnitDimensionless)
 	MCoalescedBackendLoads = stats.Int64("galaxycache/coalesced_backend_loads", "The number of coalesced successful loads from the backend getter", stats.UnitDimensionless)
+	MCoalescedPeekErrors   = stats.Int64("galaxycache/coalesced_peek_errors", "The number of coalesced remote Peek requests that failed with errors other than Not Found", stats.UnitDimensionless)
 
 	MServerRequests = stats.Int64("galaxycache/server_requests", "The number of Gets that came over the network from peers", stats.UnitDimensionless)
 	MKeyLength      = stats.Int64("galaxycache/key_length", "The length of keys", stats.UnitBytes)
@@ -83,7 +83,6 @@ var AllViews = []*view.View{
 	{Measure: MPeerLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MPeerLoadErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MPeeks, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
-	{Measure: MPeekErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MBackendLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MBackendLoadErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 
@@ -91,6 +90,7 @@ var AllViews = []*view.View{
 	{Measure: MCoalescedPeekHits, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MCoalescedLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MCoalescedCacheHits, TagKeys: []tag.Key{GalaxyKey, CacheLevelKey}, Aggregation: view.Count()},
+	{Measure: MCoalescedPeekErrors, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MCoalescedPeerLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 	{Measure: MCoalescedBackendLoads, TagKeys: []tag.Key{GalaxyKey}, Aggregation: view.Count()},
 


### PR DESCRIPTION
- **observability: add missing views**
  After deploying v1.3.0 to a dev cluster, I noticed that we were missing
  a view for Peek hits.
  
  For this change, I made a quick pass making sure that all the metrics
  defined in observability.go were referenced in `AllViews`.
  

- **metrics: Peek hits are not cache-hits**
  Remove a duplicate increment of MCacheHits that would happen on both the
  client and server-side.
  MCacheHits with hitlevel=peek would be equivalent to Peek-hits metric,
  but need to be filtered out when computing any cache-hitrate (which is
  less than useful).
  

- **GetWithOptions: rewrite doc-comment**
  I forgot to update this doc-comment after I changed the contents of
  GetOptions to use an enum. Make this a bulleted list that explains
  what's happening more clearly.
  

- **Fix peek metrics**
  The peek implementation was merged with inconsistent behavior and naming
  around the new metrics.
  
  In particular:
   - CoalescedPeeks was double-incremented (both inside peekPeer and in
     load())
   - PeekErrors was never incremented
   - CoalescedPeekHits wasn't incremented either
  