### PR TITLE
perf: remove hashMap for optimized peer selection

### DIFF
--- a/consistenthash/consistenthash_fuzz_test.go
+++ b/consistenthash/consistenthash_fuzz_test.go
@@ -48,13 +48,10 @@ func FuzzHashCollision(f *testing.F) {
 		hash2 := New(int(segments), hashFunc)
 		hash2.Add(input[:]...)
 
-		if !reflect.DeepEqual(hash1.hashMap, hash2.hashMap) {
-			t.Errorf("hash maps are not identical: %+v vs %+v", hash1.hashMap, hash2.hashMap)
+		if !reflect.DeepEqual(hash1.segments, hash2.segments) {
+			t.Errorf("segments are not identical: %+v vs %+v", hash1.segments, hash2.segments)
 		}
 		if !reflect.DeepEqual(hash1.keys, hash2.keys) {
-			t.Errorf("hash keys are not identical: %+v vs %+v", hash1.keys, hash2.keys)
-		}
-		if !reflect.DeepEqual(hash1.keyHashes, hash2.keyHashes) {
 			t.Errorf("hash keys are not identical: %+v vs %+v", hash1.keys, hash2.keys)
 		}
 	})

--- a/consistenthash/consistenthash_test.go
+++ b/consistenthash/consistenthash_test.go
@@ -75,14 +75,22 @@ func TestHashCollision(t *testing.T) {
 	hash2 := New(1, hashFunc)
 	hash2.Add("Bill", "Bonny", "Bob")
 
-	t.Log(hash1.hashMap[uint32('0')], hash2.hashMap[uint32('0')])
-	t.Logf("%+v", hash1.hashMap)
-	t.Logf("%v", hash1.keyHashes)
-	t.Logf("%+v", hash2.hashMap)
-	t.Logf("%v", hash2.keyHashes)
-	if hash1.hashMap[uint32('0')] != hash2.hashMap[uint32('0')] {
+	// Helper to find owner by hash value in segments
+	findOwner := func(m *Map, h uint32) string {
+		for _, seg := range m.segments {
+			if seg.hash == h {
+				return seg.owner
+			}
+		}
+		return ""
+	}
+
+	t.Log(findOwner(hash1, uint32('0')), findOwner(hash2, uint32('0')))
+	t.Logf("%+v", hash1.segments)
+	t.Logf("%+v", hash2.segments)
+	if findOwner(hash1, uint32('0')) != findOwner(hash2, uint32('0')) {
 		t.Errorf("inconsistent owner for hash %d: %s vs %s", 'B',
-			hash1.hashMap[uint32('B')], hash2.hashMap[uint32('B')])
+			findOwner(hash1, uint32('B')), findOwner(hash2, uint32('B')))
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR optimizes the consistent hash implementation by replacing the separate `keyHashes []uint32` slice and `hashMap map[uint32]string` with a single `segments []segment` struct slice. This eliminates the map lookup overhead in the hot path (`Get()`, `findSegmentOwner()`).

## Changes

- Added `segment` struct combining `hash uint32` and `owner string`
- Replaced `keyHashes` and `hashMap` with `segments []segment`
- Updated `findSegmentOwner()` to access segments directly (the key optimization)
- Updated `Add()` to use a temporary map during insertion for collision handling
- Updated tests to work with the new structure

## Benchmark Comparison

```
goos: darwin
goarch: arm64
cpu: Apple M1 Pro
```

| Benchmark                            | Old (ns/op) | New (ns/op) | Speedup        |
|--------------------------------------|-------------|-------------|----------------|
| Get/segs50-shards8                   | 37.99       | 34.47       | 9.3% faster    |
| Get/segs50-shards32                  | 40.66       | 37.41       | 8.0% faster    |
| Get/segs50-shards512                 | 71.94       | 65.40       | 9.1% faster    |
| GetReplicated/segs50-shards8-reps2   | 174.2       | 161.8       | 7.1% faster    |
| GetReplicated/segs50-shards32-reps2  | 181.1       | 164.1       | 9.4% faster    |
| GetReplicated/segs50-shards128-reps2 | 201.0       | 176.3       | 12.3% faster   |
| GetReplicated/segs50-shards512-reps2 | 242.9       | 203.8       | 16.1% faster   |
| GetReplicated/segs50-shards8-reps4   | 380.1       | 341.0       | 10.3% faster   |
| GetReplicated/segs50-shards32-reps4  | 391.8       | 353.1       | 9.9% faster    |
| GetReplicated/segs50-shards128-reps4 | 442.8       | 373.6       | 15.6% faster   |
| GetReplicated/segs50-shards512-reps4 | 533.6       | 446.2       | 16.4% faster   |
| GetReplicated/segs50-shards8-reps8   | 1061.0      | 823.9       | 22.4% faster   |
| GetReplicated/segs50-shards32-reps8  | 820.3       | 735.9       | 10.3% faster   |
| GetReplicated/segs50-shards128-reps8 | 936.4       | 808.2       | 13.7% faster   |
| GetReplicated/segs50-shards512-reps8 | 1109.0      | 1020.0      | 8.1% faster    |
| **Geometric Mean**                   |             |             | **11.5% faster** |

Memory allocations remain unchanged.

## Motivation

Inspired by a similar optimization in groupcache (https://github.com/groupcache/groupcache-go/pull/22). The key insight is that storing hash and owner together in a struct slice provides:

- **O(1) direct slice access** instead of map lookup after binary search
- **Slightly reduced memory footprint** (no map overhead)
