### PR TITLE
actions: add pull_request flow for fork PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
`pull_request_target` was problematic for permissions reasons, and we've
since locked down the permissions on this repo a bit. Add `pull_request`
so we can trigger workflows on third-party fork PRs.
